### PR TITLE
Allow null instead of undefined for SelectList values

### DIFF
--- a/packages/ui/src/Form.tsx
+++ b/packages/ui/src/Form.tsx
@@ -21,7 +21,7 @@ interface FormLineProps {
   value: any;
   onSave: (value: any) => void;
   kind: "boolean" | "string" | "textarea" | "select" | "multiboolean";
-  options?: (string | undefined)[];
+  options?: string[];
 }
 
 interface FormLineState {

--- a/packages/ui/src/SelectList.tsx
+++ b/packages/ui/src/SelectList.tsx
@@ -4,7 +4,8 @@ import {FieldWithLabelsProps} from "./Common";
 import RNPickerSelect from "./PickerSelect";
 import {Unifier} from "./Unifier";
 
-export type SelectListOptions = {label: string; value: string | number | undefined}[];
+// Use "" if you want to have an "unset" value.
+export type SelectListOptions = {label: string; value: string | number}[];
 export interface SelectListProps extends FieldWithLabelsProps {
   id?: string;
   name?: string;


### PR DESCRIPTION
This allows unsetting in a select list. undefined causes a warning with
the underlying library.