### PR TITLE
Fix rendering of container, remember story

### DIFF
--- a/packages/ui-demo/App.tsx
+++ b/packages/ui-demo/App.tsx
@@ -1,6 +1,7 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {useFonts} from "expo-font";
 import {StatusBar} from "expo-status-bar";
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {Pressable, ScrollView, StyleSheet, Text, View} from "react-native";
 
 import * as Stories from "./src/stories";
@@ -20,26 +21,18 @@ for (const story of stories) {
     allStories[storyName] = story.stories[storyName];
   }
 }
-console.info(
-  "ALL",
-  Object.keys(allStories),
-  stories.map((s) => s.title)
-);
-
-const renderStory = (story: Story) => {
-  return (
-    <View>
-      <Text>{story.title}</Text>
-      {Object.keys(story.stories).map((key) => {
-        const Story = story.stories[key];
-        return <Story key={key} />;
-      })}
-    </View>
-  );
-};
 
 const App = () => {
   const [currentStory, setStory] = useState<string | null>(null);
+
+  useEffect(() => {
+    AsyncStorage.getItem("story").then((story) => {
+      if (story) {
+        setStory(story);
+      }
+    });
+  }, []);
+
   const [loaded] = useFonts({
     "Comfortaa-Light": require("./assets/Comfortaa-Light.ttf"),
     "Comfortaa-Bold": require("./assets/Comfortaa-Bold.ttf"),
@@ -51,15 +44,18 @@ const App = () => {
     return null;
   }
 
-  // eslint-disable-next-line no-console
-  console.log("Hi");
   return (
     <View style={styles.container}>
       <StatusBar style="auto" />
       <View style={styles.header}>
         {!currentStory && <Text style={{fontWeight: "bold", fontSize: 20}}>Pick A Story:</Text>}
         {currentStory && (
-          <Pressable onPress={() => setStory(null)}>
+          <Pressable
+            onPress={async () => {
+              setStory(null);
+              await AsyncStorage.setItem("story", "");
+            }}
+          >
             <Text style={{fontWeight: "bold"}}>&lt; Back</Text>
           </Pressable>
         )}
@@ -75,10 +71,9 @@ const App = () => {
                 {Object.keys(s.stories).map((title) => (
                   <Pressable
                     key={title}
-                    onPress={() => {
-                      // eslint-disable-next-line no-console
-                      console.log("PRES", title);
+                    onPress={async () => {
                       setStory(title);
+                      await AsyncStorage.setItem("story", title);
                     }}
                   >
                     <Text style={{fontSize: 16, marginBottom: 8}}>{title}</Text>
@@ -98,10 +93,12 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     width: "100%",
     height: "100%",
+    maxHeight: "100%",
+    position: "absolute",
+    overflow: "hidden",
   },
   header: {
     backgroundColor: "#ccc",
-    marginTop: 30,
     display: "flex",
     flexDirection: "row",
     width: "100%",
@@ -126,7 +123,7 @@ const styles = StyleSheet.create({
     paddingRight: 16,
     paddingTop: 16,
     overflow: "scroll",
-    marginBottom: 80, // ScrollView isn't the proper height so you can't get to the bottom.
+    paddingBottom: 120, // ScrollView isn't the proper height so you can't get to the bottom.
   },
 });
 

--- a/packages/ui-demo/package.json
+++ b/packages/ui-demo/package.json
@@ -8,6 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
+    "build": "expo build:web",
     "eject": "expo eject",
     "lint": "eslint \"**/*.ts*\"",
     "lintfix": "eslint --fix \"**/*.ts*\""
@@ -49,7 +50,6 @@
     "react-native-haptic-feedback": "^1.10.0",
     "react-native-hyperlink": "^0.0.19",
     "react-native-modalize": "^2.0.12",
-    "react-native-navigation": "^6.12.0",
     "react-native-permissions": "^3.1.0",
     "react-native-picker-select": "^8.0.0",
     "react-native-portalize": "^1.0.7",

--- a/packages/ui-demo/src/SplitPage.stories.tsx
+++ b/packages/ui-demo/src/SplitPage.stories.tsx
@@ -25,7 +25,7 @@ export const SplitPageStories = {
             </Box>
           )}
           renderListViewItem={(item) => (
-            <Box color="blue" padding={2}>
+            <Box key={item.item.name} color="blue" padding={2}>
               <Text>name: {item.item.name}</Text>
             </Box>
           )}

--- a/packages/ui-demo/yarn.lock
+++ b/packages/ui-demo/yarn.lock
@@ -4197,7 +4197,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@3.x.x, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5042,7 +5042,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@4.17.x, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6141,7 +6141,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.x.x, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6314,11 +6314,6 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-lifecycles-compat@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-2.0.0.tgz#71d9c4cde47114c4102454f76da055c2bc48c948"
-  integrity sha512-txfpPCQYiazVdcbMRhatqWKcAxJweUu2wDXvts5/7Wyp6+Y9cHojqXHsLPEckzutfHlxZhG8Oiundbmp8Fd6eQ==
-
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -6361,17 +6356,6 @@ react-native-modalize@^2.0.12:
   version "2.0.13"
   resolved "https://registry.yarnpkg.com/react-native-modalize/-/react-native-modalize-2.0.13.tgz#51517cddd726ddbc19c080d15e7721ade4ee7a66"
   integrity sha512-BMJlpTnpeDVp5LbbE6kdO+3+yLzowRvPgcIu1QCCM+//uY7oON4VcL8ISilSgAfOYeNQc6vhaD5chVtmpTl/dw==
-
-react-native-navigation@^6.12.0:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-6.12.2.tgz#1389534e868fe4774a1e567b232d59496d8c4c6f"
-  integrity sha512-MwUDHebTeaAoBBkRYkLfjAB9Hx5UfbykXTlll8uLWD9oTc0fO7MZtOOal2WIwbZoBeniJvXjgQmiA4grsH6mzw==
-  dependencies:
-    hoist-non-react-statics "3.x.x"
-    lodash "4.17.x"
-    prop-types "15.x.x"
-    react-lifecycles-compat "2.0.0"
-    tslib "1.9.3"
 
 react-native-permissions@^3.1.0:
   version "3.3.1"
@@ -7431,11 +7415,6 @@ tsconfig-paths@^3.14.1:
     json5 "^1.0.1"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
-
-tslib@1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
Make it so the header renders without margin, and the body is
scrollable, rather than the whole page being scrollable to keep the
header visible.

Use async storage so we remember which story we were on while
developing. It was rather annoying when you'd update a story and then
have to scroll and click the story again to see changes.

Also add build command so we can deploy web to Netlify.