### PR TITLE
Roll back allowing numbers in SelectList

### DIFF
--- a/packages/ui-demo/src/SelectList.stories.tsx
+++ b/packages/ui-demo/src/SelectList.stories.tsx
@@ -19,7 +19,9 @@ const SelectLists = () => {
         options={options}
         placeholder="Here's some placeholder text."
         value={item}
-        onChange={(newItem) => setItem(newItem)}
+        onChange={(newItem) => {
+          setItem(newItem);
+        }}
       />
     </StorybookContainer>
   );

--- a/packages/ui/src/PickerSelect.tsx
+++ b/packages/ui/src/PickerSelect.tsx
@@ -289,10 +289,8 @@ export default class RNPickerSelect extends PureComponent<any, any> {
 
     onValueChange(value, index);
 
-    this.setState((prevState: any) => {
-      return {
-        selectedItem: prevState.items[index],
-      };
+    this.setState({
+      selectedItem: this.props.items[index],
     });
   }
 
@@ -639,7 +637,7 @@ export default class RNPickerSelect extends PureComponent<any, any> {
         <Picker
           enabled={!disabled}
           selectedValue={selectedItem.value}
-          style={style.inputWeb}
+          style={[{width: "100%", height: "100%", border: "none"}, style.inputWeb]}
           testID="web_picker"
           onValueChange={this.onValueChange}
           {...pickerProps}

--- a/packages/ui/src/SelectList.tsx
+++ b/packages/ui/src/SelectList.tsx
@@ -5,7 +5,7 @@ import RNPickerSelect from "./PickerSelect";
 import {Unifier} from "./Unifier";
 
 // Use "" if you want to have an "unset" value.
-export type SelectListOptions = {label: string; value: string | number}[];
+export type SelectListOptions = {label: string; value: string}[];
 export interface SelectListProps extends FieldWithLabelsProps {
   id?: string;
   name?: string;
@@ -17,33 +17,29 @@ export interface SelectListProps extends FieldWithLabelsProps {
   placeholder?: string;
 }
 
-export class SelectList extends React.Component<SelectListProps, {}> {
-  state = {showing: false};
-
-  render() {
-    return (
-      <RNPickerSelect
-        items={this.props.options}
-        placeholder={{}}
-        style={{
-          viewContainer: {
-            flexDirection: "row",
-            justifyContent: "center",
-            alignItems: "center",
-            minHeight: 50,
-            width: "100%",
-            // Add padding so the border doesn't mess up layouts
-            paddingHorizontal: 6,
-            paddingVertical: 4,
-            borderColor: Unifier.theme.gray,
-            borderWidth: 1,
-            borderRadius: 5,
-            backgroundColor: Unifier.theme.white,
-          },
-        }}
-        value={this.props.value}
-        onValueChange={this.props.onChange}
-      />
-    );
-  }
+export function SelectList({options, value, onChange}: SelectListProps) {
+  return (
+    <RNPickerSelect
+      items={options}
+      placeholder={{}}
+      style={{
+        viewContainer: {
+          flexDirection: "row",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: 50,
+          width: "100%",
+          // Add padding so the border doesn't mess up layouts
+          paddingHorizontal: 6,
+          paddingVertical: 4,
+          borderColor: Unifier.theme.gray,
+          borderWidth: 1,
+          borderRadius: 5,
+          backgroundColor: Unifier.theme.white,
+        },
+      }}
+      value={value}
+      onValueChange={onChange}
+    />
+  );
 }


### PR DESCRIPTION
On the web, \<option\> only accepts string for values, so do the same
in our SelectList implementation. Using numbers was causing hard to
debug issues where the wrong item would be selected.

Also make SelectList look nice on web.

![image](https://user-images.githubusercontent.com/204714/176496023-d117e4dd-6614-4e84-aed9-5e0b5df36cd5.jpeg)
