### PR TITLE
Fix error with Spinner after unmounting, convert to FC

### DIFF
--- a/packages/ui/src/Spinner.tsx
+++ b/packages/ui/src/Spinner.tsx
@@ -1,69 +1,20 @@
-import React from "react";
-import {ActivityIndicator, View} from "react-native";
+import React, {ReactElement, useEffect, useState} from "react";
+import {ActivityIndicator} from "react-native";
 
 import {SpinnerProps} from "./Common";
-import {Unifier} from "./Unifier";
 
-export class LoadingOverlay extends React.Component<SpinnerProps, {}> {
-  componentId?: string = undefined;
+export function Spinner({size, color}: SpinnerProps): ReactElement | null {
+  const [show, setShow] = useState(false);
 
-  async showHide() {
-    if (this.componentId) {
-      try {
-        await Unifier.navigation.dismissOverlay();
-      } catch (e) {
-        console.debug(`[spinner] could not dismiss spinner overlay`, e);
-      }
-    }
+  // The delay is for perceived performance. You don't want to show a spinner when you're doing a quick action.
+  useEffect(() => {
+    const timer = setTimeout(() => setShow(true), 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!show) {
+    return null;
   }
-
-  componentDidMount() {
-    this.showHide();
-  }
-
-  componentDidUpdate() {
-    this.showHide();
-  }
-
-  componentWillUnmount() {
-    this.showHide();
-  }
-
-  render() {
-    return (
-      <View
-        style={{
-          width: "100%",
-          height: "100%",
-          flex: 1,
-          justifyContent: "center",
-          alignItems: "center",
-          backgroundColor: Unifier.theme.white,
-          opacity: 0.5,
-        }}
-      >
-        <Spinner />
-      </View>
-    );
-  }
-}
-
-interface SpinnerState {
-  show: boolean;
-}
-export class Spinner extends React.Component<SpinnerProps, SpinnerState> {
-  state = {show: false};
-
-  // The delay is for perceived performance so you should rarely need to remove it.
-  componentDidMount() {
-    setTimeout(() => this.setState({show: true}), 300);
-  }
-
-  render() {
-    if (!this.state.show) {
-      return null;
-    }
-    const size: "small" | "large" = this.props.size === "sm" ? "small" : "large";
-    return <ActivityIndicator color={this.props.color || "darkGray"} size={size} />;
-  }
+  const spinnerSize: "small" | "large" = size === "sm" ? "small" : "large";
+  return <ActivityIndicator color={color || "darkGray"} size={spinnerSize} />;
 }


### PR DESCRIPTION
Remove LoadingOverlay, which was for React-Native-Navigation based
projects, which Ferns UI no longer supports.