### PR TITLE
Add Modal component

### DIFF
--- a/packages/ui-demo/src/Modal.stories.tsx
+++ b/packages/ui-demo/src/Modal.stories.tsx
@@ -1,0 +1,65 @@
+import {Box, Button, Modal, Text} from "ferns-ui";
+import React, {useState} from "react";
+
+const Modals = () => {
+  const [modalToShow, setModalToShow] = useState<string>("");
+  let size = "sm";
+  if (modalToShow === "md") {
+    size = "md";
+  } else if (modalToShow === "lg") {
+    size = "lg";
+  }
+  return (
+    <>
+      <Box>
+        <Button text="Default modal" onClick={() => setModalToShow("default")} />
+        <Button text="Start aligned modal" onClick={() => setModalToShow("start")} />
+        <Button text="Medium modal" onClick={() => setModalToShow("md")} />
+        <Button text="Large modal" onClick={() => setModalToShow("lg")} />
+        <Button text="Secondary modal" onClick={() => setModalToShow("secondary")} />
+        <Button text="Custom footer" onClick={() => setModalToShow("footer")} />
+      </Box>
+      <Modal
+        align={modalToShow === "start" ? "start" : "center"}
+        heading={`${modalToShow} modal`}
+        primaryButtonOnClick={() => setModalToShow("")}
+        primaryButtonText="Close"
+        secondaryButtonOnClick={() => {}}
+        secondaryButtonText={modalToShow === "secondary" ? "Secondary" : undefined}
+        size={size as "sm" | "md" | "lg"}
+        subHeading="Sub heading"
+        visible={
+          modalToShow === "default" ||
+          modalToShow === "start" ||
+          modalToShow === "md" ||
+          modalToShow === "lg" ||
+          modalToShow === "secondary"
+        }
+        onDismiss={() => setModalToShow("")}
+      >
+        <Text align={modalToShow === "start" ? undefined : "center"}>Some text for the modal</Text>
+      </Modal>
+      <Modal
+        footer={
+          <Box color="red" padding={2} width="100%">
+            <Button color="primary" text="Big Button" onClick={() => setModalToShow("")} />
+          </Box>
+        }
+        heading="Custom footer"
+        primaryButtonText="hi"
+        visible={modalToShow === "footer"}
+        onDismiss={() => setModalToShow("")}
+      >
+        <Text align="center">Some text for the modal</Text>
+      </Modal>
+    </>
+  );
+};
+
+export const ModalStories = {
+  title: "Modal",
+  component: Modal,
+  stories: {
+    Modals: () => <Modals />,
+  },
+};

--- a/packages/ui-demo/src/stories.tsx
+++ b/packages/ui-demo/src/stories.tsx
@@ -11,6 +11,7 @@ export * from "./Icon.stories";
 export * from "./IconButton.stories";
 export * from "./Link.stories";
 export * from "./Mask.stories";
+export * from "./Modal.stories";
 export * from "./Pill.stories";
 export * from "./SegmentedControl.stories";
 export * from "./SelectList.stories";

--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import {Dimensions, Modal as RNModal} from "react-native";
+
+import {Box} from "./Box";
+import {Button} from "./Button";
+import {Heading} from "./Heading";
+import {Text} from "./Text";
+
+interface ModalProps {
+  onDismiss: () => void;
+  visible: boolean;
+  // Alignment of the header. Default is "center".
+  align?: "center" | "start";
+  // Element to render in the middle part of the modal.
+  children?: React.ReactElement;
+  // Element to render in the bottom of the modal. This takes precedence over primaryButton and secondaryButton.
+  footer?: React.ReactElement;
+  heading?: string;
+  size?: "sm" | "md" | "lg";
+  subHeading?: string;
+  // Renders a primary colored button all the way to the right in the footer, if no footer prop is provided.
+  primaryButtonText?: string;
+  primaryButtonOnClick?: (value?: any) => void;
+  // Renders a primary gray button to the left of the primary button in the footer, if no footer prop is provided.
+  // Requires primaryButtonText to be defined, but is not required itself.
+  secondaryButtonText?: string;
+  secondaryButtonOnClick?: (value?: any) => void;
+}
+
+export const Modal = ({
+  onDismiss,
+  visible,
+  align = "center",
+  children,
+  footer,
+  heading,
+  size,
+  subHeading,
+  primaryButtonText,
+  primaryButtonOnClick,
+  secondaryButtonText,
+  secondaryButtonOnClick,
+}: ModalProps): React.ReactElement => {
+  if (subHeading && !heading) {
+    throw new Error("Cannot render Modal with subHeading and no heading");
+  }
+  if (!footer && !primaryButtonText && !secondaryButtonText) {
+    throw new Error(
+      "Cannot render Modal without footer, primaryButtonText, or secondaryButtonText"
+    );
+  }
+
+  function renderHeader(): React.ReactElement {
+    return (
+      <Box paddingY={3} width="100%">
+        <Box>
+          <Heading align={align === "center" ? "center" : undefined} size="sm">
+            {heading}
+          </Heading>
+        </Box>
+        {Boolean(subHeading) && (
+          <Box paddingY={2}>
+            <Text align={align === "center" ? "center" : undefined}>{subHeading}</Text>
+          </Box>
+        )}
+      </Box>
+    );
+  }
+  function renderFooter(): React.ReactElement | null {
+    if (footer) {
+      return footer;
+    }
+    return (
+      <Box direction="row" justifyContent="end" width="100%">
+        {Boolean(secondaryButtonText) && (
+          <Box marginRight={4} minWidth={120}>
+            <Button
+              color="gray"
+              text={secondaryButtonText ?? ""}
+              onClick={secondaryButtonOnClick}
+            />
+          </Box>
+        )}
+        <Box minWidth={120}>
+          <Button color="primary" text={primaryButtonText ?? ""} onClick={primaryButtonOnClick} />
+        </Box>
+      </Box>
+    );
+  }
+
+  let sizePx: string | number = 540;
+  if (size === "md") {
+    sizePx = 720;
+  } else if (size === "lg") {
+    sizePx = 900;
+  }
+
+  // Adjust size for small screens
+  if (sizePx > Dimensions.get("window").width) {
+    sizePx = "90%";
+  }
+
+  return (
+    <Box alignItems="center" flex="grow" height="100%" justifyContent="center" width="100%">
+      <RNModal animationType="slide" transparent visible={visible} onRequestClose={onDismiss}>
+        <Box
+          alignItems="center"
+          alignSelf="center"
+          color="white"
+          dangerouslySetInlineStyle={{
+            __style: {
+              zIndex: 1,
+              shadowColor: "#999",
+              shadowOffset: {
+                width: 4,
+                height: 6,
+              },
+              shadowRadius: 4,
+              shadowOpacity: 1.0,
+              elevation: 8,
+            },
+          }}
+          direction="column"
+          justifyContent="center"
+          marginTop={12}
+          maxWidth={sizePx}
+          minWidth={300}
+          paddingX={8}
+          paddingY={2}
+          rounding={6}
+          shadow
+          width={sizePx}
+        >
+          <Box marginBottom={6} width="100%">
+            {renderHeader()}
+            <Box paddingY={4}>{children}</Box>
+            <Box paddingY={4}>{renderFooter()}</Box>
+          </Box>
+        </Box>
+      </RNModal>
+    </Box>
+  );
+};

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,5 +1,6 @@
 export * from "./Constants";
 export * from "./Common";
+export * from "./ActionSheet";
 export * from "./Avatar";
 export * from "./Banner";
 export * from "./BlurBox";
@@ -17,7 +18,6 @@ export * from "./Form";
 export * from "./HeaderButtons";
 export * from "./Heading";
 export * from "./Icon";
-export * from "./ActionSheet";
 export * from "./IconButton";
 export * from "./Image";
 export * from "./ImageBackground";
@@ -26,7 +26,7 @@ export * from "./ImageBackground";
 export * from "./Link";
 export * from "./Mask";
 export * from "./Meta";
-// export * from "./Modal";
+export * from "./Modal";
 
 export * from "./Page";
 export * from "./Pill";


### PR DESCRIPTION
Provide a wrapper around the React Native built in Modal, based on Gestalt's Modal component.

![Screen Shot 2022-09-07 at 3 22 21 PM](https://user-images.githubusercontent.com/204714/188970379-d075d450-451a-4089-b589-94abf1357f69.jpg)
![Screen Shot 2022-09-06 at 9 49 17 PM](https://user-images.githubusercontent.com/204714/188970399-2ffe6418-e31e-4cad-988a-0853c4b8a410.jpg)
![Screen Shot 2022-09-06 at 9 49 12 PM](https://user-images.githubusercontent.com/204714/188970401-4604eb1d-f268-4294-962a-3e97edeca520.jpg)
![Screen Shot 2022-09-06 at 9 48 31 PM](https://user-images.githubusercontent.com/204714/188970402-c6412aab-a137-4eca-a92a-211ec2f1930c.jpg)
![Screen Shot 2022-09-06 at 9 48 28 PM](https://user-images.githubusercontent.com/204714/188970405-e79f8144-ce49-4073-81b2-6843df1d4c20.jpg)
![Screen Shot 2022-09-06 at 9 50 39 PM](https://user-images.githubusercontent.com/204714/188970413-15cd259c-f987-4639-b346-a1d70e6f1ebf.jpg)
![Screen Shot 2022-09-06 at 9 50 36 PM](https://user-images.githubusercontent.com/204714/188970414-7e9ad81f-af28-45bb-81c3-ca650974369e.jpg)
