### PR TITLE
Fix crash when switching between branches

### DIFF
--- a/packages/ui-demo/App.tsx
+++ b/packages/ui-demo/App.tsx
@@ -62,7 +62,7 @@ const App = () => {
         <Text style={{marginLeft: 20, fontWeight: "bold"}}>{currentStory}</Text>
       </View>
       <View style={styles.body}>
-        {currentStory && allStories[currentStory]()}
+        {currentStory && allStories[currentStory] && allStories[currentStory]()}
         {!currentStory && (
           <ScrollView style={styles.storyList}>
             {stories.map((s) => (


### PR DESCRIPTION
If the story saved to local storage doesn't exist, the app crashes. This happens when hopping between branches with new stories.