### PR TITLE
Fix calendar layering underneath things

### DIFF
--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -24,7 +24,7 @@ export const DateTimeField = ({
     >
       <WithLabel>
         <View>
-          <Box maxWidth={300}>
+          <Box flex="grow" maxWidth={300}>
             {mode === "datetime" && (
               <DateTimePickerWeb disableClock value={value} onChange={onChange} />
             )}


### PR DESCRIPTION
It was like this:
<img width="503" alt="Screen Shot 2022-09-20 at 10 08 51 AM" src="https://user-images.githubusercontent.com/6036168/191301798-c76f9bef-83e7-4af9-9012-0e874e9d676a.png">
Now like this:
<img width="402" alt="Screen Shot 2022-09-20 at 10 35 01 AM" src="https://user-images.githubusercontent.com/6036168/191301865-cadb4676-cd5b-448a-82fc-3ed81da61fc1.png">
