### PR TITLE
Fix select dropdown touchable area bug in iOs

### DIFF
--- a/packages/ui/src/PickerSelect.tsx
+++ b/packages/ui/src/PickerSelect.tsx
@@ -516,6 +516,13 @@ export default class RNPickerSelect extends PureComponent<any, any> {
       <View style={[defaultStyles.viewContainer, style.viewContainer]}>
         <TouchableOpacity
           activeOpacity={1}
+          style={{
+            flexDirection: "row",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: style?.minHeight || 50,
+            width: "100%",
+          }}
           testID="ios_touchable_wrapper"
           onPress={() => {
             this.togglePicker(true);


### PR DESCRIPTION
Touchable area before (in blue, limited only to directly over text): 
<img width="341" alt="Screen Shot 2022-09-22 at 3 10 38 PM" src="https://user-images.githubusercontent.com/66394682/191841744-6e3ee6db-d8b3-4eec-a8b2-7daf6b56f30a.png">

Touchable area after (in blue - widened):
<img width="351" alt="Screen Shot 2022-09-22 at 9 57 13 AM" src="https://user-images.githubusercontent.com/66394682/191840693-c423baa0-2fd8-4bd5-9076-3baf057f9ae2.png">


closes #86 