### PR TITLE
Change TapToEdit from uncontrolled to controlled component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -182,6 +182,7 @@
     "react": "^18.2.0",
     "react-app-polyfill": "^3.0.0",
     "react-dev-utils": "^12.0.1",
+    "react-datetime-picker": "^4.0.1",
     "react-dom": "18.2.0",
     "react-native": "0.69.4",
     "react-native-calendars": "^1.1288.2",
@@ -192,6 +193,7 @@
     "react-native-portalize": "^1.0.7",
     "react-native-svg": "^13.0.0",
     "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "react-time-picker": "^5.0.0"
   }
 }

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -26,7 +26,7 @@ export const TapToEdit = (props: TapToEditProps): ReactElement => {
   const {title, editable = true, rowBoxProps, transform, fieldComponent, ...fieldProps} = props;
   if (editing) {
     return (
-      <Box direction="column" maxWidth="100%" paddingX={3} paddingY={2} width="100%">
+      <Box direction="column">
         {fieldComponent ? (
           fieldComponent(setValue as any)
         ) : (
@@ -64,10 +64,10 @@ export const TapToEdit = (props: TapToEditProps): ReactElement => {
       </Box>
     );
   } else {
-    let displayValue = value;
-    // If transform is present, that takes priority
+    let displayValue = props.initialValue;
+    // If a transform props is present, that takes priority
     if (transform) {
-      displayValue = transform(value);
+      displayValue = transform(props.initialValue);
     } else {
       // If no transform, try and display the value reasonably.
       if (fieldProps?.type === "boolean") {
@@ -93,7 +93,6 @@ export const TapToEdit = (props: TapToEditProps): ReactElement => {
       <Box
         direction="row"
         justifyContent="between"
-        maxWidth="100%"
         paddingX={3}
         paddingY={2}
         width="100%"
@@ -102,8 +101,8 @@ export const TapToEdit = (props: TapToEditProps): ReactElement => {
         <Box>
           <Text weight="bold">{title}:</Text>
         </Box>
-        <Box direction="row" flex="shrink" marginLeft={2}>
-          <Box flex="shrink">
+        <Box direction="row">
+          <Box>
             <Text overflow="breakWord">{displayValue}</Text>
           </Box>
           {editable && (


### PR DESCRIPTION
Previously, TapToEdit was managing its state internally only. This caused a bunch of data sync issues (and was more useful in the pre-hooks era). Switch this to a controlled component to fix up a few bugs it has been experiencing.

Also update package.json for a few missing peer deps.

Note: this is upstreaming the fixes we had locally in flourish/app. 