### PR TITLE
TextInput prop update

### DIFF
--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -698,6 +698,8 @@ export interface TextFieldProps extends FieldWithLabelsProps {
   inputRef?: any;
   onSubmitEditing?: any;
   onEnter?: any;
+  // if blurOnSubmit is false and multiline is true, return will create a new line
+  blurOnSubmit?: boolean;
   multiline?: boolean;
   rows?: number;
   height?: number;

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -698,6 +698,7 @@ export interface TextFieldProps extends FieldWithLabelsProps {
   inputRef?: any;
   onSubmitEditing?: any;
   onEnter?: any;
+  // blurOnSubmit defaults to true
   // if blurOnSubmit is false and multiline is true, return will create a new line
   blurOnSubmit?: boolean;
   multiline?: boolean;

--- a/packages/ui/src/TextField.tsx
+++ b/packages/ui/src/TextField.tsx
@@ -101,6 +101,7 @@ const textContentMap = {
 };
 
 export function TextField({
+  blurOnSubmit = true,
   value,
   height: propsHeight,
   onChange,
@@ -243,7 +244,7 @@ export function TextField({
               autoCapitalize={type === "text" ? "sentences" : "none"}
               autoCorrect={shouldAutocorrect}
               autoFocus={autoFocus}
-              blurOnSubmit
+              blurOnSubmit={blurOnSubmit}
               editable={isEditable}
               keyboardType={keyboardType as KeyboardTypeOptions}
               multiline={multiline}


### PR DESCRIPTION
Add `blurOnSubmit` as prop with default value of `true` instead of always defaulting to true. Allows you to create a new line upon return in TextInput and/or TextArea by setting `multiline` to `true` and `blurOnSubmit` to `false`. 