### PR TITLE
Convert TapToEdit to controlled, add 'editing override', and fix address bug

### DIFF
--- a/packages/ui-demo/src/TapToEdit.stories.tsx
+++ b/packages/ui-demo/src/TapToEdit.stories.tsx
@@ -14,61 +14,65 @@ const TapStory = (): ReactElement => {
     <Box direction="column" display="flex" height="100%" width="100%">
       <TapToEdit
         key="text"
-        initialValue={text}
         name="text"
+        setValue={setText}
         title="Text"
         type="text"
+        value={text}
         onSave={(value): void => {
           setText(value);
         }}
       />
       <TapToEdit
         key="bool"
-        initialValue={bool}
         name="bool"
+        setValue={setBool}
         title="Boolean"
         type="boolean"
+        value={bool}
         onSave={(value): void => {
           setBool(value);
         }}
       />
       <TapToEdit
         key="currency"
-        initialValue={currency}
         name="currency"
+        setValue={setCurrency}
         title="Currency"
         type="currency"
+        value={currency}
         onSave={(value): void => {
           setCurrency(value);
         }}
       />
       <TapToEdit
         key="percent"
-        initialValue={percent}
         name="percent"
+        setValue={setPercent}
         title="Percent"
         type="percent"
+        value={percent}
         onSave={(value): void => {
           setPercent(value);
         }}
       />
       <TapToEdit
         key="select"
-        initialValue={select}
         name="select"
         options={[
           {label: "Option1", value: "Option1"},
           {label: "Option2", value: "Option2"},
         ]}
+        setValue={setSelect}
         title="Select"
         type="select"
+        value={select}
         onSave={(value): void => {
           setSelect(value);
         }}
       />
       <TapToEdit
         key="multiselect"
-        initialValue={multiselect}
         name="multiselect"
         options={[
           {label: "Option1", value: "Option1"},
@@ -79,8 +83,10 @@ const TapStory = (): ReactElement => {
             value: "Really long option for testing some wrap around and such",
           },
         ]}
+        setValue={setMultiselect}
         title="Multi Select"
         type="multiselect"
+        value={multiselect}
         onSave={(value): void => {
           setMultiselect(value);
         }}

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -38,11 +38,6 @@ export interface FieldProps extends FieldWithLabelsProps {
   disabled?: boolean;
 }
 
-/**
- * Note: You MUST set a key={} prop for this component, otherwise you may wind up with stale data. Just changing
- * initialValue will not work.
- *
- */
 export const Field = ({
   name,
   label,
@@ -156,13 +151,14 @@ export const Field = ({
         />
       );
     } else if (type === "address") {
+      const addressValue = value ? value : {};
       const {
         address1 = "",
         address2 = "",
         city = "",
         state = "",
         zipcode = "",
-      }: AddressInterface = value;
+      }: AddressInterface = addressValue;
       return (
         <>
           <TextField

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -9,11 +9,14 @@ import {Text} from "./Text";
 
 export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   title: string;
-  initialValue: any;
+  value: any;
+  setValue: (value: any) => void;
   // Not required if not editable.
   onSave?: (value: any) => void | Promise<void>;
   // Defaults to true
   editable?: boolean;
+  // enable edit mode from outside the component
+  editingOverride?: boolean;
   // For changing how the non-editing row renders
   rowBoxProps?: Partial<BoxProps>;
   transform?: (value: any) => string;
@@ -21,19 +24,20 @@ export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
 }
 
 export const TapToEdit = ({
-  initialValue,
+  value,
+  setValue,
   title,
   onSave,
   editable = true,
+  editingOverride = false,
   rowBoxProps,
   transform,
   fieldComponent,
   ...fieldProps
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(initialValue);
 
-  if (editing) {
+  if (editable && (editing || editingOverride)) {
     return (
       <Box direction="column">
         {fieldComponent ? (
@@ -41,38 +45,40 @@ export const TapToEdit = ({
         ) : (
           <Field label={title} value={value} onChange={setValue} {...fieldProps} />
         )}
-        <Box direction="row">
-          <Button
-            color="blue"
-            inline
-            text="Save"
-            onClick={async (): Promise<void> => {
-              if (!onSave) {
-                console.error("No onSave provided for editable TapToEdit");
-              } else {
-                await onSave(value);
-              }
-              setEditing(false);
-            }}
-          />
-          <Box marginLeft={2}>
+        {editing && !editingOverride && (
+          <Box direction="row">
             <Button
-              color="red"
+              color="blue"
               inline
-              text="Cancel"
-              onClick={(): void => {
+              text="Save"
+              onClick={async (): Promise<void> => {
+                if (!onSave) {
+                  console.error("No onSave provided for editable TapToEdit");
+                } else {
+                  await onSave(value);
+                }
                 setEditing(false);
               }}
             />
+            <Box marginLeft={2}>
+              <Button
+                color="red"
+                inline
+                text="Cancel"
+                onClick={(): void => {
+                  setEditing(false);
+                }}
+              />
+            </Box>
           </Box>
-        </Box>
+        )}
       </Box>
     );
   } else {
-    let displayValue = initialValue;
+    let displayValue = value;
     // If a transform props is present, that takes priority
     if (transform) {
-      displayValue = transform(initialValue);
+      displayValue = transform(value);
     } else {
       // If no transform, try and display the value reasonably.
       if (fieldProps?.type === "boolean") {

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -16,7 +16,7 @@ export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   // Defaults to true
   editable?: boolean;
   // enable edit mode from outside the component
-  editingOverride?: boolean;
+  isEditing?: boolean;
   // For changing how the non-editing row renders
   rowBoxProps?: Partial<BoxProps>;
   transform?: (value: any) => string;
@@ -29,7 +29,7 @@ export const TapToEdit = ({
   title,
   onSave,
   editable = true,
-  editingOverride = false,
+  isEditing = false,
   rowBoxProps,
   transform,
   fieldComponent,
@@ -37,7 +37,7 @@ export const TapToEdit = ({
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
 
-  if (editable && (editing || editingOverride)) {
+  if (editable && (editing || isEditing)) {
     return (
       <Box direction="column">
         {fieldComponent ? (
@@ -45,7 +45,7 @@ export const TapToEdit = ({
         ) : (
           <Field label={title} value={value} onChange={setValue} {...fieldProps} />
         )}
-        {editing && !editingOverride && (
+        {editing && !isEditing && (
           <Box direction="row">
             <Button
               color="blue"


### PR DESCRIPTION
- In order to enable a global edit function for all `TapToEdit` components, added an 'editing override' value.
- Moved to a controlled model for `TapToEdit` so the value will be available at all times in the parent component for a global save function
- Fixed bug where an undefined address caused a crash