### PR TITLE
Make setValue optional for TapToEdit

### DIFF
--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -38,6 +38,10 @@ export const TapToEdit = ({
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
 
+  if (editable && !setValue) {
+    throw new Error("setValue is required if editable is true");
+  }
+
   if (editable && (editing || isEditing)) {
     return (
       <Box direction="column">

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -10,7 +10,8 @@ import {Text} from "./Text";
 export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   title: string;
   value: any;
-  setValue: (value: any) => void;
+  // Not required if not editable.
+  setValue?: (value: any) => void;
   // Not required if not editable.
   onSave?: (value: any) => void | Promise<void>;
   // Defaults to true


### PR DESCRIPTION
If it's not editable we'd never use setValue.