### PR TITLE
Fix to support having an unselected value in a SelectList dropdown

### DIFF
--- a/packages/ui/src/CustomSelect.tsx
+++ b/packages/ui/src/CustomSelect.tsx
@@ -56,7 +56,7 @@ export const CustomSelect = ({
       <SelectList
         id="providedOptions"
         options={[...options, {label: "Custom", value: "custom"}]}
-        placeholder={placeholder || ""}
+        placeholder={placeholder}
         value={customValue}
         onChange={handleCustomSelectListChange}
       />

--- a/packages/ui/src/CustomSelect.tsx
+++ b/packages/ui/src/CustomSelect.tsx
@@ -56,7 +56,7 @@ export const CustomSelect = ({
       <SelectList
         id="providedOptions"
         options={[...options, {label: "Custom", value: "custom"}]}
-        placeholder="Select an option"
+        placeholder={placeholder || ""}
         value={customValue}
         onChange={handleCustomSelectListChange}
       />

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -77,6 +77,7 @@ export const Field = ({
           disabled={disabled}
           id={name}
           options={options}
+          placeholder={placeholder}
           value={value}
           onChange={onChange}
         />
@@ -216,7 +217,13 @@ export const Field = ({
         return null;
       }
       return (
-        <CustomSelect disabled={disabled} options={options} value={value} onChange={onChange} />
+        <CustomSelect
+          disabled={disabled}
+          options={options}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+        />
       );
     } else {
       let tfType: TextFieldType = "text";

--- a/packages/ui/src/PickerSelect.tsx
+++ b/packages/ui/src/PickerSelect.tsx
@@ -289,8 +289,10 @@ export default class RNPickerSelect extends PureComponent<any, any> {
 
     onValueChange(value, index);
 
-    this.setState({
-      selectedItem: this.props.items[index],
+    this.setState((prevState: any) => {
+      return {
+        selectedItem: prevState.items[index],
+      };
     });
   }
 

--- a/packages/ui/src/SelectList.tsx
+++ b/packages/ui/src/SelectList.tsx
@@ -20,14 +20,22 @@ export interface SelectListProps extends FieldWithLabelsProps {
   style?: StyleProp;
 }
 
-export function SelectList({options, value, onChange, label, labelColor, style}: SelectListProps) {
+export function SelectList({
+  options,
+  value,
+  onChange,
+  label,
+  labelColor,
+  style,
+  placeholder,
+}: SelectListProps) {
   const withLabelProps = {label, labelColor};
 
   return (
     <WithLabel {...withLabelProps}>
       <RNPickerSelect
         items={options}
-        placeholder={{}}
+        placeholder={{label: placeholder || "", value: ""}}
         style={{
           viewContainer: {
             flexDirection: style?.flexDirection || "row",

--- a/packages/ui/src/SelectList.tsx
+++ b/packages/ui/src/SelectList.tsx
@@ -35,7 +35,7 @@ export function SelectList({
     <WithLabel {...withLabelProps}>
       <RNPickerSelect
         items={options}
-        placeholder={{label: placeholder || "", value: ""}}
+        placeholder={placeholder ? {label: placeholder, value: ""} : {}}
         style={{
           viewContainer: {
             flexDirection: style?.flexDirection || "row",

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -43,11 +43,6 @@ export const TapToEdit = ({
   }
 
   if (editable && (editing || isEditing)) {
-    // set the value to the default value if it is undefined
-    // this will avoid issues where the user wants the initial value to be saved, particularly on a Select component
-    if (fieldProps.options && fieldProps.options.length > 0 && !value && setValue) {
-      setValue(fieldProps.options[0].value);
-    }
     return (
       <Box direction="column">
         {fieldComponent ? (

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -44,11 +44,6 @@ export const TapToEdit = ({
   }
 
   if (editable && (editing || isEditing)) {
-    // set the value to the default value if it is undefined
-    // this will avoid issues where the user wants the initial value to be saved, particularly on a Select component
-    // if (fieldProps.options && fieldProps.options.length > 0 && !value && setValue) {
-    //   setValue(fieldProps.options[0].value);
-    // }
     return (
       <Box direction="column">
         {fieldComponent ? (

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -27,6 +27,7 @@ export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
 export const TapToEdit = ({
   value,
   setValue,
+  placeholder,
   title,
   onSave,
   editable = true,
@@ -43,12 +44,23 @@ export const TapToEdit = ({
   }
 
   if (editable && (editing || isEditing)) {
+    // set the value to the default value if it is undefined
+    // this will avoid issues where the user wants the initial value to be saved, particularly on a Select component
+    // if (fieldProps.options && fieldProps.options.length > 0 && !value && setValue) {
+    //   setValue(fieldProps.options[0].value);
+    // }
     return (
       <Box direction="column">
         {fieldComponent ? (
           fieldComponent(setValue as any)
         ) : (
-          <Field label={title} value={value} onChange={setValue} {...fieldProps} />
+          <Field
+            label={title}
+            placeholder={placeholder}
+            value={value}
+            onChange={setValue}
+            {...fieldProps}
+          />
         )}
         {editing && !isEditing && (
           <Box direction="row">


### PR DESCRIPTION
Right now, when you provide a list of options to a SelectList (or any parent like TapToEdit), it defaults to the first option versus allowing it to not be a selected value.

If you don't want to support having an unselected value, you should provide an initial `value` so it doesn't use the placeholder.