### PR TITLE
Make the TapToEdit icon a little less in your face

### DIFF
--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -130,7 +130,7 @@ export const TapToEdit = ({
           </Box>
           {editable && (
             <Box marginLeft={2} onClick={(): void => setEditing(true)}>
-              <Icon color="darkGray" name="edit" size="lg" />
+              <Icon color="darkGray" name="edit" prefix="far" size="md" />
             </Box>
           )}
         </Box>


### PR DESCRIPTION
The icon was solid and looked quite large.

Now:
![Screenshot 2023-02-21 at 11 24 15 AM](https://user-images.githubusercontent.com/204714/220416596-f5f22bfd-6519-4bbd-95bc-a5cd717e4c5f.jpg)

Before:

![Screenshot 2023-02-21 at 11 24 41 AM](https://user-images.githubusercontent.com/204714/220416585-f4c828e1-ebac-42d8-ab27-a8f6555c0dcd.jpg)
