### PR TITLE
Add transform to tap-to-edit address

### DIFF
--- a/packages/ui-demo/src/TapToEdit.stories.tsx
+++ b/packages/ui-demo/src/TapToEdit.stories.tsx
@@ -9,7 +9,13 @@ const TapStory = (): ReactElement => {
   const [percent, setPercent] = useState(1.957);
   const [select, setSelect] = useState("Option1");
   const [multiselect, setMultiselect] = useState(["Option2"]);
-
+  const [address, setAddress] = useState({
+    address1: "555 N Street Ave",
+    address2: "Apt 402",
+    city: "New York",
+    state: "New York",
+    zipcode: "12345",
+  });
   return (
     <Box direction="column" display="flex" height="100%" width="100%">
       <TapToEdit
@@ -89,6 +95,16 @@ const TapStory = (): ReactElement => {
         value={multiselect}
         onSave={(value): void => {
           setMultiselect(value);
+        }}
+      />
+      <TapToEdit
+        name="address"
+        setValue={setAddress}
+        title="Address"
+        type="address"
+        value={address}
+        onSave={(value): void => {
+          setAddress(value);
         }}
       />
     </Box>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -111,16 +111,20 @@ export const TapToEdit = ({
         // ???
         displayValue = value.join(", ");
       } else if (fieldProps?.type === "address") {
-        const city = value?.city
-          ? value?.state || value.zipcode
-            ? `${value.city}, `
-            : `${value.city}`
-          : "";
-        const state = value?.state ? (value?.zipcode ? `${value.state} ` : `${value.state}`) : "";
+        let city = "";
+        if (value?.city) {
+          city = value?.state || value.zipcode ? `${value.city}, ` : `${value.city}`;
+        }
+
+        let state = "";
+        if (value?.state) {
+          state = value?.zipcode ? `${value.state} ` : `${value.state}`;
+        }
+
         const zip = value?.zipcode;
 
-        const addressLineOne = value?.address1 ? value?.address1 : "";
-        const addressLineTwo = value?.address2 ? value?.address2 : "";
+        const addressLineOne = value?.address1 ?? "";
+        const addressLineTwo = value?.address2 ?? "";
         const addressLineThree = `${city}${state}${zip}`;
 
         // Only add new lines if lines before and after are not empty to avoid awkward whitespace

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -110,6 +110,23 @@ export const TapToEdit = ({
       } else if (fieldProps?.type === "multiselect") {
         // ???
         displayValue = value.join(", ");
+      } else if (fieldProps?.type === "address") {
+        const city = value?.city
+          ? value?.state || value.zipcode
+            ? `${value.city}, `
+            : `${value.city}`
+          : "";
+        const state = value?.state ? (value?.zipcode ? `${value.state} ` : `${value.state}`) : "";
+        const zip = value?.zipcode;
+
+        const addressLineOne = value?.address1 ? value?.address1 : "";
+        const addressLineTwo = value?.address2 ? value?.address2 : "";
+        const addressLineThree = `${city}${state}${zip}`;
+
+        // Only add new lines if lines before and after are not empty to avoid awkward whitespace
+        displayValue = `${addressLineOne}${
+          addressLineOne && (addressLineTwo || addressLineThree) ? `\n` : ""
+        }${addressLineTwo}${addressLineTwo && addressLineThree ? `\n` : ""}${addressLineThree}`;
       }
     }
     return (


### PR DESCRIPTION
Tap to edit was missing a transform option for type="address". Formatted to display with no additional whitespace or commas if information is missing. 

<img width="312" alt="Screenshot 2023-03-03 at 3 52 46 PM" src="https://user-images.githubusercontent.com/66394682/222840335-965c9de8-8779-4b90-a3aa-632f827ecda8.png">
<img width="308" alt="Screenshot 2023-03-03 at 3 53 54 PM" src="https://user-images.githubusercontent.com/66394682/222840394-67d629a3-1598-4856-8e05-182026a3bfaf.png">

closes #122 
