### PR TITLE
Add Tooltips

### DIFF
--- a/packages/ui-demo/App.tsx
+++ b/packages/ui-demo/App.tsx
@@ -3,6 +3,7 @@ import {useFonts} from "expo-font";
 import {StatusBar} from "expo-status-bar";
 import React, {ReactElement, useEffect, useState} from "react";
 import {Pressable, ScrollView, StyleSheet, Text, View} from "react-native";
+import {Host} from "react-native-portalize";
 import {SafeAreaProvider, useSafeAreaInsets} from "react-native-safe-area-context";
 
 import * as Stories from "./src/stories";
@@ -47,59 +48,61 @@ const App = () => {
   }
 
   return (
-    <View
-      style={{
-        ...styles.container,
-        paddingTop: insets.top,
-        paddingBottom: insets.bottom,
-        paddingLeft: insets.left,
-        paddingRight: insets.right,
-        backgroundColor: "#fff",
-      }}
-    >
-      <StatusBar style="auto" />
-      <View style={styles.header}>
-        {!currentStory && <Text style={{fontWeight: "bold", fontSize: 20}}>Pick A Story:</Text>}
-        {currentStory && (
-          <Pressable
-            onPress={async () => {
-              setStory(null);
-              await AsyncStorage.setItem("story", "");
-            }}
-          >
-            <Text style={{fontWeight: "bold"}}>&lt; Back</Text>
-          </Pressable>
-        )}
-        <Text style={{marginLeft: 20, fontWeight: "bold"}}>{currentStory}</Text>
+    <Host>
+      <View
+        style={{
+          ...styles.container,
+          paddingTop: insets.top,
+          paddingBottom: insets.bottom,
+          paddingLeft: insets.left,
+          paddingRight: insets.right,
+          backgroundColor: "#fff",
+        }}
+      >
+        <StatusBar style="auto" />
+        <View style={styles.header}>
+          {!currentStory && <Text style={{fontWeight: "bold", fontSize: 20}}>Pick A Story:</Text>}
+          {currentStory && (
+            <Pressable
+              onPress={async () => {
+                setStory(null);
+                await AsyncStorage.setItem("story", "");
+              }}
+            >
+              <Text style={{fontWeight: "bold"}}>&lt; Back</Text>
+            </Pressable>
+          )}
+          <Text style={{marginLeft: 20, fontWeight: "bold"}}>{currentStory}</Text>
+        </View>
+        <View style={styles.body}>
+          {currentStory && allStories[currentStory] && allStories[currentStory]()}
+          {!currentStory && (
+            <ScrollView>
+              <View style={styles.storyList}>
+                {stories.map((s) => (
+                  <React.Fragment key={s.title}>
+                    <Text style={{fontWeight: "bold", fontSize: 20, marginBottom: 12}}>
+                      {s.title}
+                    </Text>
+                    {Object.keys(s.stories).map((title) => (
+                      <Pressable
+                        key={title}
+                        onPress={async () => {
+                          setStory(title);
+                          await AsyncStorage.setItem("story", title);
+                        }}
+                      >
+                        <Text style={{fontSize: 16, marginBottom: 8}}>{title}</Text>
+                      </Pressable>
+                    ))}
+                  </React.Fragment>
+                ))}
+              </View>
+            </ScrollView>
+          )}
+        </View>
       </View>
-      <View style={styles.body}>
-        {currentStory && allStories[currentStory] && allStories[currentStory]()}
-        {!currentStory && (
-          <ScrollView>
-            <View style={styles.storyList}>
-              {stories.map((s) => (
-                <React.Fragment key={s.title}>
-                  <Text style={{fontWeight: "bold", fontSize: 20, marginBottom: 12}}>
-                    {s.title}
-                  </Text>
-                  {Object.keys(s.stories).map((title) => (
-                    <Pressable
-                      key={title}
-                      onPress={async () => {
-                        setStory(title);
-                        await AsyncStorage.setItem("story", title);
-                      }}
-                    >
-                      <Text style={{fontSize: 16, marginBottom: 8}}>{title}</Text>
-                    </Pressable>
-                  ))}
-                </React.Fragment>
-              ))}
-            </View>
-          </ScrollView>
-        )}
-      </View>
-    </View>
+    </Host>
   );
 };
 

--- a/packages/ui-demo/src/Tooltip.stories.tsx
+++ b/packages/ui-demo/src/Tooltip.stories.tsx
@@ -1,0 +1,92 @@
+import {Box, Heading, IconButton, Tooltip} from "ferns-ui";
+import React from "react";
+
+const ChevronTooltip = ({
+  direction,
+  text = "Short Tooltip Text",
+}: {
+  direction: "left" | "right" | "top" | "bottom" | "none";
+  text?: string;
+}): React.ReactElement => (
+  <Tooltip direction={direction === "none" ? undefined : direction} title={text}>
+    <IconButton
+      accessibilityLabel="info"
+      bgColor="white"
+      icon={
+        direction === "none"
+          ? "question"
+          : direction === "bottom"
+          ? "chevron-down"
+          : direction === "top"
+          ? "chevron-up"
+          : `chevron-${direction}`
+      }
+      iconColor="blue"
+      onClick={() => {}}
+    />
+  </Tooltip>
+);
+
+const FiveTooltips = ({text}: {text?: string}): React.ReactElement => (
+  <Box direction="row">
+    <ChevronTooltip direction="none" text={text} />
+    <ChevronTooltip direction="top" text={text} />
+    <ChevronTooltip direction="right" text={text} />
+    <ChevronTooltip direction="bottom" text={text} />
+    <ChevronTooltip direction="left" text={text} />
+  </Box>
+);
+
+const TooltipIcon = () => {
+  return (
+    <Box direction="column" display="flex" height="100%" padding={4} width="100%">
+      <Box alignItems="center" height="100%" justifyContent="center" width="100%">
+        <Heading size="sm">Small Tooltip</Heading>
+        <FiveTooltips />
+        <Heading size="sm">Large Tooltip</Heading>
+        <FiveTooltips
+          text={
+            "Here's a much longer tooltip, to test overflows, especially on mobile, and multiple lines too!"
+          }
+        />
+      </Box>
+    </Box>
+  );
+};
+
+const TooltipOverflow = () => {
+  const text =
+    "Here's a much longer tooltip, to test overflows, especially on mobile, and multiple lines too!";
+
+  return (
+    <Box direction="column" display="flex" flex="grow" padding={4} width="100%">
+      <Box direction="row" height={40} justifyContent="between" padding={2} width="100%">
+        <FiveTooltips text={text} />
+        <FiveTooltips text={text} />
+      </Box>
+      <Box direction="column" height="85%" justifyContent="center" width="100%">
+        <Box direction="row" height={40} justifyContent="between" padding={2} width="100%">
+          <FiveTooltips text={text} />
+          <FiveTooltips text={text} />
+        </Box>
+      </Box>
+      <Box direction="row" height={40} justifyContent="between" padding={2} width="100%">
+        <FiveTooltips text={text} />
+        <FiveTooltips text={text} />
+      </Box>
+    </Box>
+  );
+};
+
+export const TooltipStories = {
+  title: "Tooltip",
+  component: Tooltip,
+  stories: {
+    TooltipIcon() {
+      return <TooltipIcon />;
+    },
+    TooltipOverflow() {
+      return <TooltipOverflow />;
+    },
+  },
+};

--- a/packages/ui-demo/src/Tooltip.stories.tsx
+++ b/packages/ui-demo/src/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import {Box, Heading, IconButton, Tooltip} from "ferns-ui";
+import {Box, Heading, IconButton, InfoTooltipButton, Tooltip} from "ferns-ui";
 import React from "react";
 
 const ChevronTooltip = ({
@@ -44,6 +44,7 @@ const FiveTooltips = ({text}: {text?: string}): React.ReactElement => (
         console.info("Click delete");
       }}
     />
+    <InfoTooltipButton text="This is info in a tooltip" />
   </Box>
 );
 

--- a/packages/ui-demo/src/Tooltip.stories.tsx
+++ b/packages/ui-demo/src/Tooltip.stories.tsx
@@ -34,6 +34,16 @@ const FiveTooltips = ({text}: {text?: string}): React.ReactElement => (
     <ChevronTooltip idealDirection="right" text={text} />
     <ChevronTooltip idealDirection="bottom" text={text} />
     <ChevronTooltip idealDirection="left" text={text} />
+    <IconButton
+      accessibilityLabel="delete"
+      bgColor="gray"
+      icon="trash"
+      iconColor="red"
+      tooltip={{text: "Deletes some stuff", idealDirection: "bottom"}}
+      onClick={() => {
+        console.info("Click delete");
+      }}
+    />
   </Box>
 );
 

--- a/packages/ui-demo/src/Tooltip.stories.tsx
+++ b/packages/ui-demo/src/Tooltip.stories.tsx
@@ -2,24 +2,24 @@ import {Box, Heading, IconButton, Tooltip} from "ferns-ui";
 import React from "react";
 
 const ChevronTooltip = ({
-  direction,
+  idealDirection,
   text = "Short Tooltip Text",
 }: {
-  direction: "left" | "right" | "top" | "bottom" | "none";
+  idealDirection: "left" | "right" | "top" | "bottom" | "none";
   text?: string;
 }): React.ReactElement => (
-  <Tooltip direction={direction === "none" ? undefined : direction} title={text}>
+  <Tooltip idealDirection={idealDirection === "none" ? undefined : idealDirection} text={text}>
     <IconButton
       accessibilityLabel="info"
       bgColor="white"
       icon={
-        direction === "none"
+        idealDirection === "none"
           ? "question"
-          : direction === "bottom"
+          : idealDirection === "bottom"
           ? "chevron-down"
-          : direction === "top"
+          : idealDirection === "top"
           ? "chevron-up"
-          : `chevron-${direction}`
+          : `chevron-${idealDirection}`
       }
       iconColor="blue"
       onClick={() => {}}
@@ -29,11 +29,11 @@ const ChevronTooltip = ({
 
 const FiveTooltips = ({text}: {text?: string}): React.ReactElement => (
   <Box direction="row">
-    <ChevronTooltip direction="none" text={text} />
-    <ChevronTooltip direction="top" text={text} />
-    <ChevronTooltip direction="right" text={text} />
-    <ChevronTooltip direction="bottom" text={text} />
-    <ChevronTooltip direction="left" text={text} />
+    <ChevronTooltip idealDirection="none" text={text} />
+    <ChevronTooltip idealDirection="top" text={text} />
+    <ChevronTooltip idealDirection="right" text={text} />
+    <ChevronTooltip idealDirection="bottom" text={text} />
+    <ChevronTooltip idealDirection="left" text={text} />
   </Box>
 );
 

--- a/packages/ui-demo/src/stories.tsx
+++ b/packages/ui-demo/src/stories.tsx
@@ -24,4 +24,5 @@ export * from "./Text.stories";
 export * from "./Theme.stories";
 // export * from "./TextArea.stories";
 export * from "./TextField.stories";
+export * from "./Tooltip.stories";
 export * from "./DateTime.stories";

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2004,24 +2004,11 @@ export interface IconProps {
   containerStyle?: any;
 }
 
-export interface IconButtonProps {
-  prefix?: IconPrefix;
-  icon: IconName;
-  accessibilityLabel: string;
-  iconColor: "darkGray" | ButtonColor | ThemeColor | Color;
-  onClick: () => void;
-  size?: IconSize;
-  bgColor?: "transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white"; // default transparent
-  disabled?: boolean;
-  selected?: boolean;
-  withConfirmation?: boolean;
-  confirmationText?: string;
-  confirmationHeading?: string;
-}
-
 export interface NavigatorProps {
   config?: any;
 }
+
+export type TooltipDirection = "top" | "bottom" | "left" | "right";
 
 export interface PillProps {
   text: string;

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, useState} from "react";
-import {TouchableOpacity, View} from "react-native";
+import {Platform, TouchableOpacity, View} from "react-native";
 
 import {
   ButtonColor,
@@ -125,7 +125,10 @@ export const IconButton = forwardRef(
       );
     }
 
-    if (tooltip) {
+    // Only add for web. This doesn't make much sense for mobile, since the action would be performed for the button
+    // as well as the tooltip appearing.
+    // TODO: Add tooltip info button next to the icon button on mobile.
+    if (tooltip && Platform.OS === "web") {
       return (
         <Tooltip idealDirection={tooltip.idealDirection} text={tooltip.text}>
           {renderIconButton()}

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -1,11 +1,40 @@
 import React, {forwardRef, useState} from "react";
-import {TouchableOpacity} from "react-native";
+import {TouchableOpacity, View} from "react-native";
 
-import {IconButtonProps, iconSizeToNumber} from "./Common";
+import {
+  ButtonColor,
+  Color,
+  IconName,
+  IconPrefix,
+  IconSize,
+  iconSizeToNumber,
+  ThemeColor,
+  TooltipDirection,
+} from "./Common";
 import {Icon} from "./Icon";
 import {Modal} from "./Modal";
 import {Text} from "./Text";
+import {Tooltip} from "./Tooltip";
 import {Unifier} from "./Unifier";
+
+export interface IconButtonProps {
+  prefix?: IconPrefix;
+  icon: IconName;
+  accessibilityLabel: string;
+  iconColor: "darkGray" | ButtonColor | ThemeColor | Color;
+  onClick: () => void;
+  size?: IconSize;
+  bgColor?: "transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white"; // default transparent
+  disabled?: boolean;
+  selected?: boolean;
+  withConfirmation?: boolean;
+  confirmationText?: string;
+  confirmationHeading?: string;
+  tooltip?: {
+    text: string;
+    idealDirection?: TooltipDirection;
+  };
+}
 
 // eslint-disable-next-line react/display-name
 export const IconButton = forwardRef(
@@ -20,13 +49,14 @@ export const IconButton = forwardRef(
       withConfirmation = false,
       confirmationText = "Are you sure you want to continue?",
       confirmationHeading = "Confirm",
+      tooltip,
     }: IconButtonProps,
     ref
   ) => {
     const [showConfirmation, setShowConfirmation] = useState(false);
 
     let opacity = 1;
-    let color;
+    let color: string;
     if (bgColor === "transparentDarkGray") {
       opacity = 0.8;
       color = Unifier.theme.darkGray;
@@ -59,38 +89,50 @@ export const IconButton = forwardRef(
       );
     };
 
-    return (
-      <>
-        <TouchableOpacity
-          ref={ref as any}
-          hitSlop={{top: 10, left: 10, bottom: 10, right: 10}}
-          style={{
-            opacity,
-            backgroundColor: color,
-            borderRadius: 100,
-            // paddingBottom: iconSizeToNumber(size) / 4,
-            // paddingTop: iconSizeToNumber(size) / 4,
-            // paddingLeft: iconSizeToNumber(size) / 2,
-            // paddingRight: iconSizeToNumber(size) / 2,
-            width: iconSizeToNumber(size) * 2.5,
-            height: iconSizeToNumber(size) * 2.5,
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-          onPress={() => {
-            Unifier.utils.haptic();
-            if (withConfirmation && !showConfirmation) {
-              setShowConfirmation(true);
-            } else if (onClick) {
-              onClick();
-            }
-          }}
-        >
-          <Icon color={iconColor} name={icon} prefix={prefix || "fas"} size={size} />
-        </TouchableOpacity>
-        {Boolean(withConfirmation) && renderConfirmation()}
-      </>
-    );
+    function renderIconButton(): React.ReactElement {
+      return (
+        <View>
+          <TouchableOpacity
+            ref={ref as any}
+            hitSlop={{top: 10, left: 10, bottom: 10, right: 10}}
+            style={{
+              opacity,
+              backgroundColor: color,
+              borderRadius: 100,
+              // paddingBottom: iconSizeToNumber(size) / 4,
+              // paddingTop: iconSizeToNumber(size) / 4,
+              // paddingLeft: iconSizeToNumber(size) / 2,
+              // paddingRight: iconSizeToNumber(size) / 2,
+              width: iconSizeToNumber(size) * 2.5,
+              height: iconSizeToNumber(size) * 2.5,
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+            onPress={() => {
+              Unifier.utils.haptic();
+              if (withConfirmation && !showConfirmation) {
+                setShowConfirmation(true);
+              } else if (onClick) {
+                onClick();
+              }
+            }}
+          >
+            <Icon color={iconColor} name={icon} prefix={prefix || "fas"} size={size} />
+          </TouchableOpacity>
+          {Boolean(withConfirmation) && renderConfirmation()}
+        </View>
+      );
+    }
+
+    if (tooltip) {
+      return (
+        <Tooltip idealDirection={tooltip.idealDirection} text={tooltip.text}>
+          {renderIconButton()}
+        </Tooltip>
+      );
+    } else {
+      return renderIconButton();
+    }
   }
 );

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {forwardRef, useState} from "react";
 import {TouchableOpacity} from "react-native";
 
 import {IconButtonProps, iconSizeToNumber} from "./Common";
@@ -7,83 +7,90 @@ import {Modal} from "./Modal";
 import {Text} from "./Text";
 import {Unifier} from "./Unifier";
 
-export function IconButton({
-  prefix,
-  icon,
-  iconColor,
-  onClick,
-  size,
-  bgColor = "transparent",
-  withConfirmation = false,
-  confirmationText = "Are you sure you want to continue?",
-  confirmationHeading = "Confirm",
-}: IconButtonProps) {
-  const [showConfirmation, setShowConfirmation] = useState(false);
+// eslint-disable-next-line react/display-name
+export const IconButton = forwardRef(
+  (
+    {
+      prefix,
+      icon,
+      iconColor,
+      onClick,
+      size,
+      bgColor = "transparent",
+      withConfirmation = false,
+      confirmationText = "Are you sure you want to continue?",
+      confirmationHeading = "Confirm",
+    }: IconButtonProps,
+    ref
+  ) => {
+    const [showConfirmation, setShowConfirmation] = useState(false);
 
-  let opacity = 1;
-  let color;
-  if (bgColor === "transparentDarkGray") {
-    opacity = 0.8;
-    color = Unifier.theme.darkGray;
-  } else if (bgColor === "transparent" || !bgColor) {
-    opacity = 0.0;
-    color = Unifier.theme.white;
-  } else {
-    color = Unifier.theme[bgColor];
-  }
+    let opacity = 1;
+    let color;
+    if (bgColor === "transparentDarkGray") {
+      opacity = 0.8;
+      color = Unifier.theme.darkGray;
+    } else if (bgColor === "transparent" || !bgColor) {
+      opacity = 0.0;
+      color = Unifier.theme.white;
+    } else {
+      color = Unifier.theme[bgColor];
+    }
 
-  const renderConfirmation = () => {
-    return (
-      <Modal
-        heading={confirmationHeading}
-        primaryButtonOnClick={() => {
-          onClick();
-          setShowConfirmation(false);
-        }}
-        primaryButtonText="Confirm"
-        secondaryButtonOnClick={(): void => setShowConfirmation(false)}
-        secondaryButtonText="Cancel"
-        size="sm"
-        visible={showConfirmation}
-        onDismiss={(): void => {
-          setShowConfirmation(false);
-        }}
-      >
-        <Text>{confirmationText}</Text>
-      </Modal>
-    );
-  };
-
-  return (
-    <>
-      <TouchableOpacity
-        hitSlop={{top: 10, left: 10, bottom: 10, right: 10}}
-        style={{
-          opacity,
-          backgroundColor: color,
-          borderRadius: 100,
-          // paddingBottom: iconSizeToNumber(size) / 4,
-          // paddingTop: iconSizeToNumber(size) / 4,
-          // paddingLeft: iconSizeToNumber(size) / 2,
-          // paddingRight: iconSizeToNumber(size) / 2,
-          width: iconSizeToNumber(size) * 2.5,
-          height: iconSizeToNumber(size) * 2.5,
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-        onPress={() => {
-          Unifier.utils.haptic();
-          if (withConfirmation && !showConfirmation) {
-            setShowConfirmation(true);
-          } else if (onClick) {
+    const renderConfirmation = () => {
+      return (
+        <Modal
+          heading={confirmationHeading}
+          primaryButtonOnClick={() => {
             onClick();
-          }
-        }}
-      >
-        <Icon color={iconColor} name={icon} prefix={prefix || "fas"} size={size} />
-      </TouchableOpacity>
-      {Boolean(withConfirmation) && renderConfirmation()}
-    </>
-  );
-}
+            setShowConfirmation(false);
+          }}
+          primaryButtonText="Confirm"
+          secondaryButtonOnClick={(): void => setShowConfirmation(false)}
+          secondaryButtonText="Cancel"
+          size="sm"
+          visible={showConfirmation}
+          onDismiss={(): void => {
+            setShowConfirmation(false);
+          }}
+        >
+          <Text>{confirmationText}</Text>
+        </Modal>
+      );
+    };
+
+    return (
+      <>
+        <TouchableOpacity
+          ref={ref as any}
+          hitSlop={{top: 10, left: 10, bottom: 10, right: 10}}
+          style={{
+            opacity,
+            backgroundColor: color,
+            borderRadius: 100,
+            // paddingBottom: iconSizeToNumber(size) / 4,
+            // paddingTop: iconSizeToNumber(size) / 4,
+            // paddingLeft: iconSizeToNumber(size) / 2,
+            // paddingRight: iconSizeToNumber(size) / 2,
+            width: iconSizeToNumber(size) * 2.5,
+            height: iconSizeToNumber(size) * 2.5,
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+          onPress={() => {
+            Unifier.utils.haptic();
+            if (withConfirmation && !showConfirmation) {
+              setShowConfirmation(true);
+            } else if (onClick) {
+              onClick();
+            }
+          }}
+        >
+          <Icon color={iconColor} name={icon} prefix={prefix || "fas"} size={size} />
+        </TouchableOpacity>
+        {Boolean(withConfirmation) && renderConfirmation()}
+      </>
+    );
+  }
+);

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -61,7 +61,7 @@ export const IconButton = forwardRef(
       opacity = 0.8;
       color = Unifier.theme.darkGray;
     } else if (bgColor === "transparent" || !bgColor) {
-      opacity = 0.0;
+      opacity = 1.0;
       color = Unifier.theme.white;
     } else {
       color = Unifier.theme[bgColor];

--- a/packages/ui/src/InfoTooltipButton.tsx
+++ b/packages/ui/src/InfoTooltipButton.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import {IconSize} from "./Common";
+import {IconButton} from "./IconButton";
+
+interface InfoTooltipButtonProps {
+  text: string;
+  size?: IconSize;
+}
+
+export function InfoTooltipButton({text, size}: InfoTooltipButtonProps): React.ReactElement {
+  return (
+    <IconButton
+      accessibilityLabel="info"
+      bgColor="transparent"
+      icon="exclamation"
+      iconColor="blue"
+      size={size}
+      tooltip={{text}}
+      onClick={() => {}}
+    />
+  );
+}

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -1,0 +1,267 @@
+import * as React from "react";
+import {forwardRef} from "react";
+import {
+  Dimensions,
+  LayoutChangeEvent,
+  LayoutRectangle,
+  Platform,
+  Pressable,
+  View,
+} from "react-native";
+import {Portal} from "react-native-portalize";
+
+import {Text} from "./Text";
+import {Unifier} from "./Unifier";
+
+const TOOLTIP_OFFSET = 8;
+// How many pixels to leave between the tooltip and the edge of the screen
+const TOOLTIP_OVERFLOW_PADDING = 20;
+
+type ChildrenMeasurement = {
+  width: number;
+  height: number;
+  pageX: number;
+  pageY: number;
+};
+
+type TooltipLayout = LayoutRectangle;
+
+type TooltipDirection = "top" | "bottom" | "left" | "right";
+type Measurement = {
+  children: ChildrenMeasurement;
+  tooltip: TooltipLayout;
+  measured: boolean;
+  direction?: TooltipDirection;
+};
+
+const overflowLeft = (x: number): boolean => {
+  return x < TOOLTIP_OVERFLOW_PADDING;
+};
+
+const overflowRight = (x: number): boolean => {
+  const {width: layoutWidth} = Dimensions.get("window");
+  return x + TOOLTIP_OVERFLOW_PADDING > layoutWidth;
+};
+
+const getPosition = (
+  {
+    pageY: childrenY,
+    height: childrenHeight,
+    pageX: childrenX,
+    width: childrenWidth,
+  }: ChildrenMeasurement,
+  {width: tooltipWidth, height: tooltipHeight}: TooltipLayout,
+  direction?: TooltipDirection
+): {left: number; top: number} => {
+  const horizontalCenter = childrenX + childrenWidth / 2;
+  const right = childrenX + childrenWidth + TOOLTIP_OFFSET;
+  const left = childrenX - tooltipWidth - TOOLTIP_OFFSET;
+
+  const top = childrenY - tooltipHeight - TOOLTIP_OFFSET;
+  const bottom = childrenY + childrenHeight + TOOLTIP_OFFSET;
+  const verticalCenter = top + childrenHeight + TOOLTIP_OFFSET;
+
+  // Top is overflowed if it would go off either side or the top of the screen.
+  const overflowTop = top < TOOLTIP_OVERFLOW_PADDING;
+
+  // Bottom is overflowed if it would go off either side or the bottom of the screen.
+  const overflowBottom =
+    bottom + tooltipHeight + TOOLTIP_OVERFLOW_PADDING > Dimensions.get("window").height;
+
+  // If it would overflow to the right, try to put it above, if not, put it on the left.
+  // If it would overflow to the left, try to put it above, if not, put it to the right.
+
+  // Happy path:
+  if (direction === "left" && !overflowLeft(left)) {
+    return {left, top: verticalCenter};
+  } else if (direction === "right" && !overflowRight(right + tooltipWidth)) {
+    return {left: right, top: verticalCenter};
+  } else if (
+    direction === "bottom" &&
+    !overflowBottom &&
+    !overflowLeft(horizontalCenter - tooltipWidth) &&
+    !overflowRight(horizontalCenter + tooltipWidth)
+  ) {
+    return {left: horizontalCenter - tooltipWidth / 2, top: bottom};
+  } else {
+    // At this point, we're either trying to place it above or below, and force it into the viewport.
+
+    let y = top;
+    if ((direction === "bottom" && !overflowBottom) || overflowTop) {
+      y = bottom;
+    }
+
+    // If it fits in the viewport, center it above the child.
+    if (
+      !overflowLeft(horizontalCenter - tooltipWidth) &&
+      !overflowRight(horizontalCenter + tooltipWidth)
+    ) {
+      return {left: horizontalCenter - tooltipWidth / 2, top: y};
+    }
+    // Failing that, if it fits on the left, put it there, otherwise to the right. We know it's smaller than the
+    // viewport.
+    else if (overflowLeft(horizontalCenter - tooltipWidth)) {
+      return {left: TOOLTIP_OVERFLOW_PADDING, top: y};
+    } else {
+      return {
+        left: Dimensions.get("window").width - TOOLTIP_OVERFLOW_PADDING - tooltipWidth,
+        top: y,
+      };
+    }
+  }
+};
+
+const getTooltipPosition = ({
+  children,
+  tooltip,
+  measured,
+  direction,
+}: Measurement): {} | {left: number; top: number} => {
+  if (!measured) {
+    console.debug("No measurements for child yet, cannot show tooltip.");
+    return {};
+  }
+
+  return getPosition(children, tooltip, direction);
+};
+
+interface TooltipProps {
+  children: React.ReactElement;
+  title: string;
+  direction?: "top" | "bottom" | "left" | "right";
+  bgColor?: "white" | "lightGray" | "gray" | "darkGray";
+}
+
+// eslint-disable-next-line react/display-name
+export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
+  const {title, children, bgColor, direction} = props;
+  const hoverDelay = 500;
+  const hoverEndDelay = 1500;
+  const [visible, setVisible] = React.useState(false);
+
+  const [measurement, setMeasurement] = React.useState({
+    children: {},
+    tooltip: {},
+    measured: false,
+  });
+  const showTooltipTimer = React.useRef<NodeJS.Timeout>();
+  const hideTooltipTimer = React.useRef<NodeJS.Timeout>();
+  const childrenWrapperRef = React.useRef() as React.MutableRefObject<View>;
+
+  const touched = React.useRef(false);
+
+  const isWeb = Platform.OS === "web";
+
+  React.useEffect(() => {
+    return () => {
+      if (showTooltipTimer.current) {
+        clearTimeout(showTooltipTimer.current);
+      }
+
+      if (hideTooltipTimer.current) {
+        clearTimeout(hideTooltipTimer.current);
+      }
+    };
+  }, []);
+
+  const handleOnLayout = ({nativeEvent: {layout}}: LayoutChangeEvent) => {
+    childrenWrapperRef?.current?.measure((_x, _y, width, height, pageX, pageY) => {
+      setMeasurement({
+        children: {pageX, pageY, height, width},
+        tooltip: {...layout},
+        measured: true,
+      });
+    });
+  };
+
+  const handleTouchStart = () => {
+    if (hideTooltipTimer.current) {
+      clearTimeout(hideTooltipTimer.current);
+    }
+
+    showTooltipTimer.current = setTimeout(() => {
+      touched.current = true;
+      setVisible(true);
+    }, 100) as unknown as NodeJS.Timeout;
+  };
+
+  const handleHoverIn = () => {
+    if (hideTooltipTimer.current) {
+      clearTimeout(hideTooltipTimer.current);
+    }
+
+    showTooltipTimer.current = setTimeout(() => {
+      touched.current = true;
+      setVisible(true);
+    }, hoverDelay) as unknown as NodeJS.Timeout;
+  };
+
+  const handleHoverOut = () => {
+    touched.current = false;
+    if (showTooltipTimer.current) {
+      clearTimeout(showTooltipTimer.current);
+    }
+
+    hideTooltipTimer.current = setTimeout(() => {
+      setVisible(false);
+      setMeasurement({children: {}, tooltip: {}, measured: false});
+    }, hoverEndDelay) as unknown as NodeJS.Timeout;
+  };
+
+  const mobilePressProps = {
+    onPress: React.useCallback(() => {
+      if (touched.current) {
+        return null;
+      } else {
+        return children.props.onClick?.();
+      }
+    }, [children.props]),
+  };
+
+  const webPressProps = {
+    onHoverIn: () => {
+      handleHoverIn();
+      children.props.onHoverIn?.();
+    },
+    onHoverOut: () => {
+      handleHoverOut();
+      children.props.onHoverOut?.();
+    },
+  };
+
+  return (
+    <>
+      {visible && (
+        <Portal>
+          <Pressable
+            style={{
+              alignSelf: "flex-start",
+              justifyContent: "center",
+              paddingHorizontal: 16,
+              backgroundColor: Unifier.theme[bgColor ?? "darkGray"],
+              borderRadius: 16,
+              paddingVertical: 8,
+              display: "flex",
+              flexShrink: 1,
+              maxWidth: Math.max(Dimensions.get("window").width - 32, 300),
+              ...getTooltipPosition({...(measurement as Measurement), direction}),
+              ...(measurement.measured ? {opacity: 1} : {opacity: 0}),
+            }}
+            testID="tooltip-container"
+            onLayout={handleOnLayout}
+            onPress={() => {
+              setVisible(false);
+            }}
+          >
+            <Text color="white">{title}</Text>
+          </Pressable>
+        </Portal>
+      )}
+      <Pressable onTouchStart={handleTouchStart} {...(isWeb ? webPressProps : mobilePressProps)}>
+        {React.cloneElement(children, {
+          ref: childrenWrapperRef,
+        })}
+      </Pressable>
+    </>
+  );
+});

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -31,7 +31,7 @@ type Measurement = {
   children: ChildrenMeasurement;
   tooltip: TooltipLayout;
   measured: boolean;
-  direction?: TooltipDirection;
+  idealDirection?: TooltipDirection;
 };
 
 const overflowLeft = (x: number): boolean => {
@@ -51,7 +51,7 @@ const getPosition = (
     width: childrenWidth,
   }: ChildrenMeasurement,
   {width: tooltipWidth, height: tooltipHeight}: TooltipLayout,
-  direction?: TooltipDirection
+  idealDirection?: TooltipDirection
 ): {left: number; top: number} => {
   const horizontalCenter = childrenX + childrenWidth / 2;
   const right = childrenX + childrenWidth + TOOLTIP_OFFSET;
@@ -72,12 +72,12 @@ const getPosition = (
   // If it would overflow to the left, try to put it above, if not, put it to the right.
 
   // Happy path:
-  if (direction === "left" && !overflowLeft(left)) {
+  if (idealDirection === "left" && !overflowLeft(left)) {
     return {left, top: verticalCenter};
-  } else if (direction === "right" && !overflowRight(right + tooltipWidth)) {
+  } else if (idealDirection === "right" && !overflowRight(right + tooltipWidth)) {
     return {left: right, top: verticalCenter};
   } else if (
-    direction === "bottom" &&
+    idealDirection === "bottom" &&
     !overflowBottom &&
     !overflowLeft(horizontalCenter - tooltipWidth) &&
     !overflowRight(horizontalCenter + tooltipWidth)
@@ -87,7 +87,7 @@ const getPosition = (
     // At this point, we're either trying to place it above or below, and force it into the viewport.
 
     let y = top;
-    if ((direction === "bottom" && !overflowBottom) || overflowTop) {
+    if ((idealDirection === "bottom" && !overflowBottom) || overflowTop) {
       y = bottom;
     }
 
@@ -115,26 +115,26 @@ const getTooltipPosition = ({
   children,
   tooltip,
   measured,
-  direction,
+  idealDirection,
 }: Measurement): {} | {left: number; top: number} => {
   if (!measured) {
     console.debug("No measurements for child yet, cannot show tooltip.");
     return {};
   }
 
-  return getPosition(children, tooltip, direction);
+  return getPosition(children, tooltip, idealDirection);
 };
 
 interface TooltipProps {
   children: React.ReactElement;
-  title: string;
-  direction?: "top" | "bottom" | "left" | "right";
+  text: string;
+  idealDirection?: "top" | "bottom" | "left" | "right";
   bgColor?: "white" | "lightGray" | "gray" | "darkGray";
 }
 
 // eslint-disable-next-line react/display-name
 export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
-  const {title, children, bgColor, direction} = props;
+  const {text, children, bgColor, idealDirection} = props;
   const hoverDelay = 500;
   const hoverEndDelay = 1500;
   const [visible, setVisible] = React.useState(false);
@@ -244,7 +244,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
               display: "flex",
               flexShrink: 1,
               maxWidth: Math.max(Dimensions.get("window").width - 32, 300),
-              ...getTooltipPosition({...(measurement as Measurement), direction}),
+              ...getTooltipPosition({...(measurement as Measurement), idealDirection}),
               ...(measurement.measured ? {opacity: 1} : {opacity: 0}),
             }}
             testID="tooltip-container"
@@ -253,7 +253,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
               setVisible(false);
             }}
           >
-            <Text color="white">{title}</Text>
+            <Text color="white">{text}</Text>
           </Pressable>
         </Portal>
       )}

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import {Portal} from "react-native-portalize";
 
+import {TooltipDirection} from "./Common";
 import {Text} from "./Text";
 import {Unifier} from "./Unifier";
 
@@ -24,12 +25,9 @@ type ChildrenMeasurement = {
   pageY: number;
 };
 
-type TooltipLayout = LayoutRectangle;
-
-type TooltipDirection = "top" | "bottom" | "left" | "right";
 type Measurement = {
   children: ChildrenMeasurement;
-  tooltip: TooltipLayout;
+  tooltip: LayoutRectangle;
   measured: boolean;
   idealDirection?: TooltipDirection;
 };
@@ -43,16 +41,24 @@ const overflowRight = (x: number): boolean => {
   return x + TOOLTIP_OVERFLOW_PADDING > layoutWidth;
 };
 
-const getPosition = (
-  {
+const getTooltipPosition = ({
+  children,
+  tooltip,
+  measured,
+  idealDirection,
+}: Measurement): {} | {left: number; top: number} => {
+  if (!measured) {
+    console.debug("No measurements for child yet, cannot show tooltip.");
+    return {};
+  }
+
+  const {
     pageY: childrenY,
     height: childrenHeight,
     pageX: childrenX,
     width: childrenWidth,
-  }: ChildrenMeasurement,
-  {width: tooltipWidth, height: tooltipHeight}: TooltipLayout,
-  idealDirection?: TooltipDirection
-): {left: number; top: number} => {
+  }: ChildrenMeasurement = children;
+  const {width: tooltipWidth, height: tooltipHeight} = tooltip;
   const horizontalCenter = childrenX + childrenWidth / 2;
   const right = childrenX + childrenWidth + TOOLTIP_OFFSET;
   const left = childrenX - tooltipWidth - TOOLTIP_OFFSET;
@@ -111,20 +117,6 @@ const getPosition = (
   }
 };
 
-const getTooltipPosition = ({
-  children,
-  tooltip,
-  measured,
-  idealDirection,
-}: Measurement): {} | {left: number; top: number} => {
-  if (!measured) {
-    console.debug("No measurements for child yet, cannot show tooltip.");
-    return {};
-  }
-
-  return getPosition(children, tooltip, idealDirection);
-};
-
 interface TooltipProps {
   children: React.ReactElement;
   text: string;
@@ -165,7 +157,9 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
   }, []);
 
   const handleOnLayout = ({nativeEvent: {layout}}: LayoutChangeEvent) => {
+    console.log("onLayout", layout, childrenWrapperRef?.current);
     childrenWrapperRef?.current?.measure((_x, _y, width, height, pageX, pageY) => {
+      console.log("MESAURED");
       setMeasurement({
         children: {pageX, pageY, height, width},
         tooltip: {...layout},
@@ -229,6 +223,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
     },
   };
 
+  console.log("RENDER", visible);
   return (
     <>
       {visible && (

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -157,9 +157,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
   }, []);
 
   const handleOnLayout = ({nativeEvent: {layout}}: LayoutChangeEvent) => {
-    console.log("onLayout", layout, childrenWrapperRef?.current);
     childrenWrapperRef?.current?.measure((_x, _y, width, height, pageX, pageY) => {
-      console.log("MESAURED");
       setMeasurement({
         children: {pageX, pageY, height, width},
         tooltip: {...layout},
@@ -223,7 +221,6 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
     },
   };
 
-  console.log("RENDER", visible);
   return (
     <>
       {visible && (

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -22,6 +22,7 @@ export * from "./Icon";
 export * from "./IconButton";
 export * from "./Image";
 export * from "./ImageBackground";
+export * from "./InfoTooltipButton";
 // export * from "./Layout";
 // export * from "./Drawer";
 export * from "./Link";

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -41,6 +41,7 @@ export * from "./TapToEdit";
 export * from "./Text";
 export * from "./TextArea";
 export * from "./TextField";
+export * from "./Tooltip";
 export * from "./UnifiedScreens";
 export * from "./Unifier";
 export * from "./WithLabel";


### PR DESCRIPTION
Add a tooltip wrapper component to wrap any element and make it have a tooltip that shows on hover on web and on touch on mobile.
Add a tooltip prop to icon button. Many of the icon buttons should have explanation (currently web only).
Add a TooltipInfoButton for an easy way to add tooltip info to apps.

Tooltips with lots of ideal directions:
![Screenshot 2023-03-06 at 1 06 41 PM](https://user-images.githubusercontent.com/204714/223207362-45531106-e14c-486f-8d98-876c660fbd76.jpg)

Testing overflow:
![Screenshot 2023-03-06 at 1 06 16 PM](https://user-images.githubusercontent.com/204714/223207367-7df45af1-da8f-4525-ad0a-55d5ded68c27.jpg)
