### PR TITLE
Catch tooltip error

### DIFF
--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -157,6 +157,10 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
   }, []);
 
   const handleOnLayout = ({nativeEvent: {layout}}: LayoutChangeEvent) => {
+    if (childrenWrapperRef?.current && !childrenWrapperRef?.current?.measure) {
+      console.error("Tooltip: childrenWrapperRef does not have a measure method.");
+      return;
+    }
     childrenWrapperRef?.current?.measure((_x, _y, width, height, pageX, pageY) => {
       setMeasurement({
         children: {pageX, pageY, height, width},


### PR DESCRIPTION
If the child doesn't have a measure function, this would throw an error. I'm not exactly sure when this would be true (maybe a fragment?).