### PR TITLE
Fix losing focus with error messages

### DIFF
--- a/packages/ui-demo/src/Field.stories.tsx
+++ b/packages/ui-demo/src/Field.stories.tsx
@@ -36,6 +36,23 @@ const BooleanField = () => {
   );
 };
 
+const FieldWithError = () => {
+  const [value, setValue] = useState("");
+  return (
+    <StorybookContainer>
+      <Field
+        errorMessage={value.length > 1 ? "Error message" : undefined}
+        helperText="Only enter 1 character, enter 2 to see the error label"
+        label="Field with error"
+        name="boolean"
+        type="text"
+        value={value}
+        onChange={setValue}
+      />
+    </StorybookContainer>
+  );
+};
+
 const EmailTextField = () => {
   const [value, setValue] = useState("test@email.com");
   return (
@@ -330,7 +347,6 @@ export const FieldStories = {
     "Percent Field": function () {
       return <PercentField />;
     },
-
     "Select Field": function () {
       return <SelectField />;
     },
@@ -354,6 +370,9 @@ export const FieldStories = {
     },
     "Custom Select Field": function () {
       return <CustomSelectField />;
+    },
+    "Field With Error Message": function () {
+      return <FieldWithError />;
     },
   },
 };

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2068,17 +2068,6 @@ export interface TextFieldProps extends FieldWithLabelsProps {
 
 export type TextAreaProps = TextFieldProps;
 
-export interface WithLabelProps {
-  children: React.ReactNode;
-  show?: boolean;
-  label?: string;
-  labelInline?: boolean;
-  labelColor?: AllColors;
-  labelJustifyContent?: JustifyContent;
-  labelPlacement?: "before" | "after";
-  labelSize?: TextSize;
-}
-
 export interface SubmittingFormProps {
   onSubmitEditting: () => void;
 }

--- a/packages/ui/src/WithLabel.tsx
+++ b/packages/ui/src/WithLabel.tsx
@@ -1,44 +1,51 @@
 import React from "react";
 
 import {Box} from "./Box";
-import {WithLabelProps} from "./Common";
+import {AllColors, JustifyContent, TextSize} from "./Common";
 import {Text} from "./Text";
 
-export class WithLabel extends React.Component<WithLabelProps, {}> {
-  render() {
-    const {label, labelInline, labelColor, children} = this.props;
-    // If show is undefined or true, show, only hide for actual false for simplicity.
+export interface WithLabelProps {
+  children: React.ReactNode;
+  show?: boolean;
+  label?: string;
+  labelInline?: boolean;
+  labelColor?: AllColors;
+  labelJustifyContent?: JustifyContent;
+  labelPlacement?: "before" | "after";
+  labelSize?: TextSize;
+}
 
-    if (!children) {
-      return null;
-    }
-
-    if (label) {
-      return (
-        <Box
-          direction={labelInline ? "row" : "column"}
-          justifyContent={this.props.labelJustifyContent}
-          width="100%"
-        >
-          {this.props.labelPlacement !== "after" && (
-            <Box paddingY={1}>
-              <Text color={labelColor || "darkGray"} size={this.props.labelSize} weight="bold">
-                {this.props.show !== false ? label : " "}
-              </Text>
-            </Box>
-          )}
-          {children}
-          {this.props.labelPlacement === "after" && (
-            <Box paddingY={1}>
-              <Text color={labelColor || "darkGray"} size={this.props.labelSize}>
-                {this.props.show !== false ? label : " "}
-              </Text>
-            </Box>
-          )}
+export function WithLabel({
+  label,
+  labelInline,
+  labelJustifyContent,
+  labelPlacement,
+  labelSize,
+  labelColor,
+  show,
+  children,
+}: WithLabelProps) {
+  return (
+    <Box
+      direction={labelInline ? "row" : "column"}
+      justifyContent={labelJustifyContent}
+      width="100%"
+    >
+      {Boolean(label && labelPlacement !== "after") && (
+        <Box paddingY={1}>
+          <Text color={labelColor || "darkGray"} size={labelSize} weight="bold">
+            {show !== false ? label : " "}
+          </Text>
         </Box>
-      );
-    } else {
-      return children;
-    }
-  }
+      )}
+      {children}
+      {Boolean(label && labelPlacement === "after") && (
+        <Box paddingY={1}>
+          <Text color={labelColor || "darkGray"} size={labelSize}>
+            {show !== false ? label : " "}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
 }


### PR DESCRIPTION
When an error message label was rendered or removed, the wrapped field was recreated, so focus was lost. Now we keep the tree the same but conditionally render only the sibling label components, so the field is not recreated.
Turn WithLabel into a functional component.