### PR TITLE
Default zip code to empty for TapToEdit

### DIFF
--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -121,7 +121,7 @@ export const TapToEdit = ({
           state = value?.zipcode ? `${value.state} ` : `${value.state}`;
         }
 
-        const zip = value?.zipcode;
+        const zip = value?.zipcode || "";
 
         const addressLineOne = value?.address1 ?? "";
         const addressLineTwo = value?.address2 ?? "";


### PR DESCRIPTION
This is causing the display value for TapToEdit to show 'undefined' when an address is empty. It should just be an empty string, and that is what this fixes.