### PR TITLE
Add Table component

### DIFF
--- a/packages/ui-demo/src/Table.stories.tsx
+++ b/packages/ui-demo/src/Table.stories.tsx
@@ -1,0 +1,123 @@
+import {Box, Button, Table, TableHeader, TableHeaderCell, TableRow, Text} from "ferns-ui";
+import sortBy from "lodash/sortBy";
+import React, {useState} from "react";
+
+const SortableExpandableTable = () => {
+  const [rows, setRows] = useState([
+    ["Data 1 has some data in it", "Data 2 has some longer data in it", 5, 1000.4],
+    ["Row 2 short", "Row 2 long", 10, 2000.0],
+    [
+      "Row 3 very long, lots of overflow here, wow is this still going? I hope it all fits!",
+      "Row 3 long",
+      1,
+      2,
+    ],
+  ]);
+
+  const renderDrawerContents = (index: number) => {
+    return (
+      <Box paddingY={8}>
+        <Text>Drawer contents for row {index}</Text>
+        <Button text="Console.log()" onClick={() => console.info("Button clicked")} />
+      </Box>
+    );
+  };
+
+  const setSort = (direction: "asc" | "desc" | undefined, index: number): void => {
+    if (!direction) {
+      setRows(rows);
+    } else {
+      direction === "asc" ? setRows(sortBy(rows, index)) : setRows(sortBy(rows, index).reverse());
+    }
+  };
+
+  return (
+    <Table columns={[160, 200, 120, 200]}>
+      <TableHeader>
+        <TableHeaderCell
+          index={0}
+          sortable
+          onSortChange={(direction) => {
+            setSort(direction, 0);
+          }}
+        >
+          <Text>Column 1</Text>
+        </TableHeaderCell>
+        <TableHeaderCell
+          index={1}
+          sortable
+          onSortChange={(direction) => {
+            setSort(direction, 1);
+          }}
+        >
+          <Text>Column 2</Text>
+        </TableHeaderCell>
+        <TableHeaderCell
+          index={2}
+          sortable
+          onSortChange={(direction) => {
+            setSort(direction, 2);
+          }}
+        >
+          <Text>Column 3</Text>
+        </TableHeaderCell>
+        <TableHeaderCell
+          index={3}
+          sortable
+          onSortChange={(direction) => {
+            setSort(direction, 3);
+          }}
+        >
+          <Text>Cost</Text>
+        </TableHeaderCell>
+      </TableHeader>
+      {rows.map((row, index) => (
+        <TableRow key={row[0]} drawerContents={renderDrawerContents(index)}>
+          <Text>{row[0]}</Text>
+          <Text>{row[1]}</Text>
+          <Text>{row[2]}</Text>
+          <Text>{`$${(row[2] as number).toFixed(2)}`}</Text>
+        </TableRow>
+      ))}
+    </Table>
+  );
+};
+
+export const TableStories = {
+  title: "Table",
+  component: Table,
+  stories: {
+    StandardTable() {
+      return (
+        <Box color="white" width="100%">
+          <Table columns={[80, 200, 200, 80]}>
+            <TableHeader>
+              <TableHeaderCell index={0}>
+                <Text>Column 1</Text>
+              </TableHeaderCell>
+              <TableHeaderCell index={1}>
+                <Text>Column 2</Text>
+              </TableHeaderCell>
+              <TableHeaderCell index={2}>
+                <Text>Column 3</Text>
+              </TableHeaderCell>
+              <TableHeaderCell index={2}>
+                <Text>Cost</Text>
+              </TableHeaderCell>
+            </TableHeader>
+            <TableRow>
+              <Text>Data 1 has some data in it</Text>
+              <Text>Data 2 has some longer data in it</Text>
+              <Text>Data 3 is short</Text>
+            </TableRow>
+          </Table>
+        </Box>
+      );
+    },
+    SortableExpandableTable: () => (
+      <Box color="white" width="100%">
+        <SortableExpandableTable />
+      </Box>
+    ),
+  },
+};

--- a/packages/ui-demo/src/Table.stories.tsx
+++ b/packages/ui-demo/src/Table.stories.tsx
@@ -76,7 +76,7 @@ const SortableExpandableTable = () => {
           <Text>{row[0]}</Text>
           <Text>{row[1]}</Text>
           <Text>{row[2]}</Text>
-          <Text>{`$${(row[2] as number).toFixed(2)}`}</Text>
+          <Text>{`$${(row[3] as number).toFixed(2)}`}</Text>
         </TableRow>
       ))}
     </Table>

--- a/packages/ui-demo/src/stories.tsx
+++ b/packages/ui-demo/src/stories.tsx
@@ -20,6 +20,7 @@ export * from "./SelectList.stories";
 export * from "./Spinner.stories";
 export * from "./SplitPage.stories";
 export * from "./Switch.stories";
+export * from "./Table.stories";
 export * from "./TapToEdit.stories";
 export * from "./Text.stories";
 export * from "./TextField.stories";

--- a/packages/ui/src/Box.tsx
+++ b/packages/ui/src/Box.tsx
@@ -269,6 +269,7 @@ export class Box extends React.Component<BoxProps, {}> {
           contentContainerStyle={{justifyContent, alignContent, alignItems}}
           horizontal={this.props.overflow === "scrollX"}
           keyboardShouldPersistTaps="handled"
+          nestedScrollEnabled
           scrollEventThrottle={50}
           style={scrollStyle}
           onScroll={(event) => {

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -1,4 +1,5 @@
 import React, {ReactElement} from "react";
+import DatePicker from "react-date-picker";
 import DateTimePickerWeb from "react-datetime-picker";
 import TimePicker from "react-time-picker";
 
@@ -24,7 +25,7 @@ export const DateTimeField = ({
         {mode === "datetime" && (
           <DateTimePickerWeb disableClock value={value} onChange={onChange} />
         )}
-        {/* {mode === "date" && <DatePicker value={value} onChange={onChange} />} */}
+        {mode === "date" && <DatePicker value={value} onChange={onChange} />}
         {mode === "time" && (
           <TimePicker
             disableClock

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -1,5 +1,4 @@
 import React, {ReactElement} from "react";
-import DatePicker from "react-date-picker";
 import DateTimePickerWeb from "react-datetime-picker";
 import TimePicker from "react-time-picker";
 
@@ -25,7 +24,7 @@ export const DateTimeField = ({
         {mode === "datetime" && (
           <DateTimePickerWeb disableClock value={value} onChange={onChange} />
         )}
-        {mode === "date" && <DatePicker value={value} onChange={onChange} />}
+        {/* {mode === "date" && <DatePicker value={value} onChange={onChange} />} */}
         {mode === "time" && (
           <TimePicker
             disableClock

--- a/packages/ui/src/Table.tsx
+++ b/packages/ui/src/Table.tsx
@@ -39,6 +39,9 @@ export function Table({children, columns, borderStyle, maxHeight}: TableProps): 
     width = columns.reduce((acc, curr) => {
       return (acc as number) + (curr as number);
     }, 0);
+    if (hasDrawerContents) {
+      width = (width as number) + 30;
+    }
   } else {
     width = "100%";
   }

--- a/packages/ui/src/Table.tsx
+++ b/packages/ui/src/Table.tsx
@@ -1,0 +1,66 @@
+import React, {Children, ReactElement, useRef} from "react";
+
+import {Box} from "./Box";
+import {ScrollView} from "./ScrollView";
+import {ColumnSortInterface, TableContextProvider} from "./tableContext";
+
+interface TableProps {
+  /**
+   * Must be instances of TableHeader, TableRow, and/or TableFooter components.
+   */
+  children: React.ReactNode | React.ReactNode[];
+  /**
+   * Width of columns in the table. This is used to calculate the width of each column. Can be numbers for pixels or strings for percentages.
+   */
+  columns: Array<number | string>;
+  /**
+   * Specify a border width for Table: "sm" is 1px.
+   */
+  borderStyle?: "sm" | "none";
+  /**
+   * Use numbers for pixels: `maxHeight={100}` and strings for percentages: `maxHeight="100%"`.
+   */
+  maxHeight?: number | string;
+}
+
+export function Table({children, columns, borderStyle, maxHeight}: TableProps): React.ReactElement {
+  const tableRef = useRef(null);
+  const arrayChildren = Children.toArray(children);
+  const [sortColumn, setSortColumn] = React.useState<ColumnSortInterface | undefined>(undefined);
+
+  // Check if any of the rows below have a drawerContents prop to see if we need to render space for the caret.
+  const hasDrawerContents = arrayChildren.some((child) => {
+    return (child as ReactElement).props?.drawerContents;
+  });
+
+  // Calculate the total width of the table. If the table has only number widths, calculate a width. Otherwise use 100%.
+  let width: string | number;
+  if (columns.every((column) => typeof column === "number")) {
+    width = columns.reduce((acc, curr) => {
+      return (acc as number) + (curr as number);
+    }, 0);
+  } else {
+    width = "100%";
+  }
+
+  return (
+    <TableContextProvider
+      columns={columns}
+      hasDrawerContents={hasDrawerContents}
+      setSortColumn={setSortColumn}
+      sortColumn={sortColumn}
+    >
+      <ScrollView horizontal style={{width, maxWidth: "100%"}}>
+        <Box
+          width={width}
+          {...(borderStyle === "sm" ? {borderStyle: "sm", rounding: 1} : {})}
+          ref={tableRef}
+          flex="grow"
+          maxHeight={maxHeight}
+        >
+          {children}
+        </Box>
+      </ScrollView>
+    </TableContextProvider>
+  );
+}

--- a/packages/ui/src/TableHeader.tsx
+++ b/packages/ui/src/TableHeader.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import {Box} from "./Box";
+import {TableRow} from "./TableRow";
+
+interface TableHeaderProps {
+  /**
+   * Must be an instance of TableRow.
+   */
+  children: React.ReactNode | React.ReactNode[];
+  /**
+   * Display `visuallyHidden` ensures the component is visually hidden but still is read by screen readers.
+   */
+  display?: "tableHeaderGroup" | "visuallyHidden";
+  /**
+   * If true, the table header will be sticky and the table body will be scrollable. Not yet implemented.
+   */
+  sticky?: boolean;
+}
+
+/**
+ * Use TableHeader to group the header content in Table.
+ */
+export function TableHeader({
+  children,
+  display = "tableHeaderGroup",
+}: TableHeaderProps): React.ReactElement {
+  return (
+    <Box display={display === "visuallyHidden" ? "none" : "flex"}>
+      <TableRow headerRow>{children}</TableRow>
+    </Box>
+  );
+}

--- a/packages/ui/src/TableHeaderCell.tsx
+++ b/packages/ui/src/TableHeaderCell.tsx
@@ -1,0 +1,76 @@
+import React, {ReactElement} from "react";
+
+import {Box} from "./Box";
+import {IconButton} from "./IconButton";
+import {useTableContext} from "./tableContext";
+
+interface Props {
+  /**
+   * The content of the table header cell.
+   */
+  children: ReactElement;
+  index: number;
+  sortable?: boolean;
+  onSortChange?: (direction: "asc" | "desc" | undefined) => void;
+}
+
+/**
+ * Use TableHeaderCell to define a header cell in Table.
+ */
+export function TableHeaderCell({children, index, sortable, onSortChange}: Props): ReactElement {
+  const {columns, setSortColumn, sortColumn} = useTableContext();
+  const width = columns[index];
+  if (!width) {
+    console.warn(`No width defined for column ${index} in TableHeaderCell`);
+  }
+
+  const onClick = () => {
+    // desc => asc => undefined
+    const newSort = sort === "desc" ? "asc" : sort === "asc" ? undefined : "desc";
+    if (setSortColumn) {
+      setSortColumn(newSort ? {column: index, direction: newSort} : undefined);
+    }
+    onSortChange && onSortChange(newSort);
+  };
+  const sort = sortColumn?.column === index ? sortColumn.direction : undefined;
+
+  if (sortable) {
+    if (!onSortChange) {
+      console.error("onSortChange is required when sortable is true");
+    }
+    return (
+      <Box
+        alignItems="center"
+        direction="row"
+        flex="grow"
+        justifyContent="between"
+        marginBottom={2}
+        marginTop={2}
+        maxWidth={width}
+        minHeight={36}
+        width={width}
+        onClick={onClick}
+      >
+        {children}
+        {Boolean(sort) && (
+          <Box paddingX={2}>
+            <IconButton
+              accessibilityLabel="sort"
+              bgColor="white"
+              icon={sort === "asc" ? "arrow-down" : "arrow-up"}
+              iconColor="darkGray"
+              size="sm"
+              onClick={() => {}}
+            />
+          </Box>
+        )}
+      </Box>
+    );
+  } else {
+    return (
+      <Box marginBottom={2} marginTop={2} width={width}>
+        {children}
+      </Box>
+    );
+  }
+}

--- a/packages/ui/src/TableRow.tsx
+++ b/packages/ui/src/TableRow.tsx
@@ -1,0 +1,87 @@
+import React, {Children, useRef} from "react";
+
+import {Box} from "./Box";
+import {IconButton} from "./IconButton";
+import {useTableContext} from "./tableContext";
+
+interface Props {
+  /**
+   * Must be instances of TableCell or TableHeaderCell.
+   */
+  children: React.ReactNode | React.ReactNode[];
+  /**
+   * Header rows have an extra thick bottom border.
+   */
+  headerRow?: boolean;
+  /**
+   * Whether the row should start expanded or not.
+   */
+  expanded?: boolean;
+  /**
+   * When the row is expanded, the drawerContents are shown. If not
+   */
+  drawerContents?: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * Use TableRow to define a row in Table.
+ */
+export function TableRow({
+  children,
+  headerRow = false,
+  expanded,
+  drawerContents,
+}: Props): React.ReactElement {
+  const [isExpanded, setIsExpanded] = React.useState(expanded || false);
+  const {columns, hasDrawerContents} = useTableContext();
+  const rowRef = useRef<Box>(null);
+
+  const renderCellWithColumnIndex = (child: React.ReactNode, index: number) => {
+    if (!columns[index]) {
+      console.warn(`No width defined for column ${index} in TableRow`);
+      return null;
+    }
+    return (
+      <Box paddingX={2} width={columns[index]}>
+        {child}
+      </Box>
+    );
+  };
+
+  const border = {__style: {borderBottom: `${headerRow ? 2 : 1}px solid #e0e0e0`}};
+
+  return (
+    <Box
+      ref={rowRef}
+      dangerouslySetInlineStyle={border}
+      marginBottom={1}
+      marginTop={1}
+      width="100%"
+    >
+      <Box direction="row" width="100%">
+        {Boolean(drawerContents) && (
+          <Box width={30}>
+            <IconButton
+              accessibilityLabel="expand"
+              bgColor="white"
+              icon={isExpanded ? "chevron-up" : "chevron-down"}
+              iconColor="darkGray"
+              size="sm"
+              onClick={() => {
+                setIsExpanded(!isExpanded);
+              }}
+            />
+          </Box>
+        )}
+        {/* Still render a blank space so the columns line up. */}
+        {Boolean(hasDrawerContents && !drawerContents) && <Box width={30} />}
+        {Children.map(children, renderCellWithColumnIndex)}
+      </Box>
+      {Boolean(isExpanded) && (
+        <Box paddingX={2} width="100%">
+          {drawerContents}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -55,6 +55,10 @@ export * from "./NumberPickerActionSheet";
 export * from "./ModalSheet";
 export * from "./ProgressBar";
 export * from "./DateTimeField";
+export * from "./Table";
+export * from "./TableHeader";
+export * from "./TableHeaderCell";
+export * from "./TableRow";
 
 // Lifted from react-native
 type ImageRequireSource = number;

--- a/packages/ui/src/tableContext.tsx
+++ b/packages/ui/src/tableContext.tsx
@@ -1,0 +1,43 @@
+import React, {Context, createContext, useContext} from "react";
+
+export interface ColumnSortInterface {
+  column: number | undefined;
+  direction: "asc" | "desc" | undefined;
+}
+
+interface TableContextType {
+  columns: Array<number | string>;
+  hasDrawerContents: boolean;
+  sortColumn?: ColumnSortInterface | undefined;
+  setSortColumn?: (sort: ColumnSortInterface | undefined) => void;
+}
+
+interface Props extends TableContextType {
+  children: React.ReactElement;
+}
+
+const TableContext: Context<TableContextType> = createContext<TableContextType>({
+  columns: [],
+  hasDrawerContents: false,
+  sortColumn: undefined,
+  setSortColumn: () => {},
+});
+
+export const {Provider} = TableContext;
+
+export function TableContextProvider({
+  children,
+  columns,
+  hasDrawerContents,
+  sortColumn,
+  setSortColumn,
+}: Props): React.ReactElement<typeof Provider> {
+  return (
+    <Provider value={{columns, hasDrawerContents, sortColumn, setSortColumn}}>{children}</Provider>
+  );
+}
+
+export function useTableContext(): TableContextType {
+  const {columns, hasDrawerContents, setSortColumn, sortColumn} = useContext(TableContext);
+  return {columns, hasDrawerContents, setSortColumn, sortColumn};
+}


### PR DESCRIPTION
Add Table and components for building out tables using rows, headers, and header cells. Use TableContext to more easily coordinate between all the different components in a Table.

One choice is to require widths for the table on setup (not based on the content) and use horizontal scrolling to put tables at full size on mobile devices. This might not always be the right choice, but tables are always hard to do with mobile, so this at least gives a consistent looking table on all three platforms.

![Screenshot 2023-04-18 at 4 10 10 PM](https://user-images.githubusercontent.com/204714/232910457-32110ec4-c83f-41c3-81b7-a89219ec8687.jpg)
![Screenshot 2023-04-18 at 4 09 44 PM](https://user-images.githubusercontent.com/204714/232910460-214858ec-feae-4c36-8751-e94ae9c85cab.jpg)
