### PR TITLE
revert to initial value upon cancel when editing with TapToEdit

### DIFF
--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -62,6 +62,7 @@ export const TapToEdit = ({
   ...fieldProps
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
+  const [initialValue] = useState(value);
 
   if (editable && !setValue) {
     throw new Error("setValue is required if editable is true");
@@ -102,6 +103,9 @@ export const TapToEdit = ({
                 inline
                 text="Cancel"
                 onClick={(): void => {
+                  if (setValue) {
+                    setValue(initialValue);
+                  }
                   setEditing(false);
                 }}
               />


### PR DESCRIPTION
closes #238 

Previously, the tap to edit value retained changes after selecting "cancel". This causes the changes to revert back to the initial value provided upon cancel. 