### PR TITLE
Fix erroneous warning for missing multiselect options

### DIFF
--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -85,7 +85,7 @@ export const Field = ({
         />
       );
     } else if (type === "multiselect") {
-      if (!options) {
+      if (options === undefined) {
         console.error("Field with type=multiselect require options");
         return undefined;
       }


### PR DESCRIPTION
We shouldn't warn when options is an empty list, which happens if the multiselect options are loaded over the network and the Field is still rendered.