### PR TITLE
Fix tooltips

### DIFF
--- a/packages/ui-demo/src/Tooltip.stories.tsx
+++ b/packages/ui-demo/src/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import {Box, Heading, IconButton, InfoTooltipButton, Tooltip} from "ferns-ui";
+import {Box, Heading, IconButton, InfoTooltipButton, Text, Tooltip} from "ferns-ui";
 import React from "react";
 
 const ChevronTooltip = ({
@@ -51,14 +51,24 @@ const TooltipIcon = () => {
   return (
     <Box direction="column" display="flex" height="100%" padding={4} width="100%">
       <Box alignItems="center" height="100%" justifyContent="center" width="100%">
-        <Heading size="sm">Small Tooltip</Heading>
-        <FiveTooltips />
-        <Heading size="sm">Large Tooltip</Heading>
-        <FiveTooltips
-          text={
-            "Here's a much longer tooltip, to test overflows, especially on mobile, and multiple lines too!"
-          }
-        />
+        <Box paddingY={2}>
+          <Heading size="sm">Small Tooltip</Heading>
+          <FiveTooltips />
+        </Box>
+        <Box paddingY={2}>
+          <Heading size="sm">Large Tooltip</Heading>
+          <FiveTooltips
+            text={
+              "Here's a much longer tooltip, to test overflows, especially on mobile, and multiple lines too!"
+            }
+          />
+        </Box>
+        <Box paddingY={2}>
+          <Heading size="sm">Tooltip on Text</Heading>
+          <Tooltip text="Text Tooltip">
+            <Text>This text has a tooltip.</Text>
+          </Tooltip>
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {forwardRef} from "react";
 import {
   Dimensions,
   LayoutChangeEvent,
@@ -124,8 +123,7 @@ interface TooltipProps {
   bgColor?: "white" | "lightGray" | "gray" | "darkGray";
 }
 
-// eslint-disable-next-line react/display-name
-export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
+export const Tooltip = (props: TooltipProps) => {
   const {text, children, bgColor, idealDirection} = props;
   const hoverDelay = 500;
   const hoverEndDelay = 1500;
@@ -180,7 +178,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
     showTooltipTimer.current = setTimeout(() => {
       touched.current = true;
       setVisible(true);
-    }, 100) as unknown as NodeJS.Timeout;
+    }, 100);
   };
 
   const handleHoverIn = () => {
@@ -191,7 +189,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
     showTooltipTimer.current = setTimeout(() => {
       touched.current = true;
       setVisible(true);
-    }, hoverDelay) as unknown as NodeJS.Timeout;
+    }, hoverDelay);
   };
 
   const handleHoverOut = () => {
@@ -203,7 +201,7 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
     hideTooltipTimer.current = setTimeout(() => {
       setVisible(false);
       setMeasurement({children: {}, tooltip: {}, measured: false});
-    }, hoverEndDelay) as unknown as NodeJS.Timeout;
+    }, hoverEndDelay);
   };
 
   const mobilePressProps = {
@@ -214,17 +212,6 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
         return children.props.onClick?.();
       }
     }, [children.props]),
-  };
-
-  const webPressProps = {
-    onHoverIn: () => {
-      handleHoverIn();
-      children.props.onHoverIn?.();
-    },
-    onHoverOut: () => {
-      handleHoverOut();
-      children.props.onHoverOut?.();
-    },
   };
 
   return (
@@ -255,13 +242,21 @@ export const Tooltip = forwardRef((props: TooltipProps, _ref: any) => {
           </Pressable>
         </Portal>
       )}
-      <Pressable
+      <View
         ref={childrenWrapperRef}
+        onPointerEnter={() => {
+          handleHoverIn();
+          children.props.onHoverIn?.();
+        }}
+        onPointerLeave={() => {
+          handleHoverOut();
+          children.props.onHoverOut?.();
+        }}
         onTouchStart={handleTouchStart}
-        {...(isWeb ? webPressProps : mobilePressProps)}
+        {...(!isWeb && mobilePressProps)}
       >
         {children}
-      </Pressable>
+      </View>
     </>
   );
-});
+};


### PR DESCRIPTION
I think tooltips got broken in Expo 49, probably the react-native-web version getting bumped. There's an existing bug for why we can't have nested Pressables. The fun thing was if you got your mouse into the corner of an IconButton (IconButtons are round, the surrounding Pressable is square), you'd get a tooltip, but as soon as you entered the child Pressable, the tooltip was cleared.

So to fix it, use the new onPointer* events on View from React Native. These are added since Android and iOS devices can now have mice, styluses, etc and mobile should support them too. So in our implementation, we allow tooltips on hover on all 3 platforms, though normal mobile device still won't get them (because you can't hover with touch).

https://github.com/necolas/react-native-web/issues/1875