### PR TITLE
Fix Google Maps link and add demo

### DIFF
--- a/packages/ui-demo/src/Field.stories.tsx
+++ b/packages/ui-demo/src/Field.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import dayjs from "dayjs";
-import {Box, Field, Text} from "ferns-ui";
+import {Box, Field, TapToEdit, Text} from "ferns-ui";
 import React, {useState} from "react";
 
 import {StorybookContainer} from "./StorybookContainer";
@@ -309,6 +309,15 @@ const AddressField = () => {
           type="address"
           value={value}
           onChange={setValue}
+        />
+        <TapToEdit
+          isEditing={false}
+          name="address"
+          setValue={setValue}
+          title="Address"
+          type="address"
+          value={value}
+          onSave={setValue}
         />
       </Box>
     </StorybookContainer>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -192,7 +192,9 @@ export const TapToEdit = ({
               onClick={
                 () =>
                   Linking.openURL(
-                    `https://www.google.com/maps/search/?q=${formatAddress(value, true)}`
+                    `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                      formatAddress(value, true)
+                    )}`
                   )
                 // eslint-disable-next-line react/jsx-curly-newline
               }


### PR DESCRIPTION
We weren't following the right pattern required by Google for a cross-platform, universal link that auto-opens Google Maps. It worked on web before, but not mobile. Now it works on both.

Also added a simple demo since we didn't have one before. Not sure if we want to add a 'TapToEdit' section within our demo app at some point? It's mostly overlap, but is slightly different.