### PR TITLE
Make Field.name optional

### DIFF
--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2172,7 +2172,6 @@ export interface BackButtonInterface {
 }
 
 export interface CheckBoxProps {
-  id: string;
   onChange: ({value}: {value: boolean}) => void;
   checked?: boolean;
   disabled?: boolean;

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -107,7 +107,6 @@ export const Field = ({
                   key={o.label + o.value}
                   checked={(value ?? []).includes(o.value)}
                   disabled={disabled}
-                  id={name}
                   name={name}
                   size="sm"
                   onChange={(result) => {

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -13,7 +13,7 @@ import {TextArea} from "./TextArea";
 import {TextField} from "./TextField";
 
 export interface FieldProps extends FieldWithLabelsProps {
-  name: string;
+  name?: string;
   label?: string;
   height?: number;
   type?:


### PR DESCRIPTION
This was required back in the pre-hook days, because it would send the name along with the result for this.setState. Hooks made that better.