### PR TITLE
Reduce hoverEndDelay to 0 so that the tooltip doesn't linger after UI changes

### DIFF
--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -129,7 +129,7 @@ export const Tooltip = (props: TooltipProps) => {
   const {theme} = useContext(ThemeContext);
   const {text, children, bgColor, idealDirection} = props;
   const hoverDelay = 500;
-  const hoverEndDelay = 1500;
+  const hoverEndDelay = 0;
   const [visible, setVisible] = React.useState(false);
 
   const [measurement, setMeasurement] = React.useState({


### PR DESCRIPTION
Tooltips tend to linger if routing to a different page or any structural ui changes. Reducing the tooltip delay to 0 fixes this.