### PR TITLE
Allow clearing select lists

### DIFF
--- a/packages/ui-demo/src/SelectList.stories.tsx
+++ b/packages/ui-demo/src/SelectList.stories.tsx
@@ -10,7 +10,7 @@ const options: SelectListOptions = [
 ];
 
 const SelectLists = () => {
-  const [item, setItem] = useState(options[0].value);
+  const [item, setItem] = useState<string | undefined>(options[0].value);
 
   return (
     <StorybookContainer>
@@ -23,12 +23,22 @@ const SelectLists = () => {
           setItem(newItem);
         }}
       />
+      <SelectList
+        allowClear
+        id="none"
+        label="Allows clear"
+        options={options}
+        value={item}
+        onChange={(newItem) => {
+          setItem(newItem);
+        }}
+      />
     </StorybookContainer>
   );
 };
 
 const WithLabel = () => {
-  const [item, setItem] = useState(options[0].value);
+  const [item, setItem] = useState<string | undefined>(options[0].value);
 
   return (
     <StorybookContainer>
@@ -45,7 +55,7 @@ const WithLabel = () => {
 };
 
 const Disabled = () => {
-  const [item, setItem] = useState(options[0].value);
+  const [item, setItem] = useState<string | undefined>(options[0].value);
 
   return (
     <StorybookContainer>

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2655,7 +2655,7 @@ export interface ButtonProps {
 
 export interface CustomSelectProps {
   value: string;
-  onChange: (value: string) => void;
+  onChange: (value?: string) => void;
   options: Array<{label: string; value: string}>;
   placeholder?: string;
   disabled?: boolean;

--- a/packages/ui/src/CustomSelect.tsx
+++ b/packages/ui/src/CustomSelect.tsx
@@ -33,7 +33,7 @@ export const CustomSelect = ({
 
   // Custom select has 3 values - the overall field value, the value of the select menu,
   // and the value of the custom input
-  const handleCustomSelectListChange = (newValue: string) => {
+  const handleCustomSelectListChange = (newValue?: string) => {
     // If "custom" is selected from the dropdown, toggle the custom input open and clear the
     // previous value
     if (newValue === "custom") {

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -211,7 +211,7 @@ export const Field = ({
             testID={`${testID}-state`}
             value={state}
             onChange={(result) => {
-              handleAddressChange("state", result);
+              handleAddressChange("state", result!);
             }}
           />
           <TextField

--- a/packages/ui/src/SelectList.tsx
+++ b/packages/ui/src/SelectList.tsx
@@ -13,12 +13,14 @@ export interface SelectListProps extends FieldWithLabelsProps {
   id?: string;
   name?: string;
   options: SelectListOptions;
-  onChange: (value: string) => void;
+  // TODO: Update types for SelectList so that value can be undefined only if allowClear is true.
+  onChange: (value?: string) => void;
   value?: string;
   disabled?: boolean;
   size?: "md" | "lg";
   placeholder?: string;
   style?: StyleProp<RNPickerSelectProps["style"]>;
+  allowClear?: boolean;
 }
 
 export const SelectList = ({
@@ -30,6 +32,7 @@ export const SelectList = ({
   style,
   placeholder,
   disabled,
+  allowClear,
 }: SelectListProps) => {
   const {theme} = useContext(ThemeContext);
 
@@ -50,7 +53,7 @@ export const SelectList = ({
           ) : null;
         }}
         disabled={disabled}
-        items={options}
+        items={allowClear ? [{label: placeholder ?? "---", value: ""}, ...options] : options}
         placeholder={placeholder ? {label: placeholder, value: ""} : {}}
         style={{
           viewContainer: {
@@ -83,7 +86,13 @@ export const SelectList = ({
           },
         }}
         value={value}
-        onValueChange={onChange}
+        onValueChange={(v) => {
+          if (allowClear && value === "") {
+            onChange(undefined);
+          } else {
+            onChange(v);
+          }
+        }}
       />
     </WithLabel>
   );

--- a/packages/ui/src/Toast.tsx
+++ b/packages/ui/src/Toast.tsx
@@ -30,9 +30,11 @@ export function useToast(): {
   return {
     show,
     warn: (text: string, options?: Omit<ToastProps["data"], "variant">): string => {
+      console.warn(text);
       return show(text, {...options, variant: "warning"});
     },
     error: (text: string, options?: Omit<ToastProps["data"], "variant">): string => {
+      console.error(text);
       return show(text, {...options, variant: "error"});
     },
     hide: (id: string) => toast.hide(id),

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -60,6 +60,7 @@ export * from "./Tooltip";
 export * from "./UnifiedAddressAutoComplete";
 export * from "./Unifier";
 export * from "./useStoredState";
+export * from "./Utilities";
 export * from "./WebAddressAutocomplete";
 export * from "./WithLabel";
 // export * from "./Layout";


### PR DESCRIPTION
Add prop to SelectList to handle clearing values better. If allowClear is passed, by default, an option with "---" will be added at the top of the select list, and when selected, it will send undefined to the parent component.