### PR TITLE
Fix calendar issues around first of the month

### DIFF
--- a/packages/ui/src/DateTimeActionSheet.tsx
+++ b/packages/ui/src/DateTimeActionSheet.tsx
@@ -398,15 +398,15 @@ export const DateTimeActionSheet = ({
     // Check if the date is T00:00:00.000Z (it should be), otherwise treat it as a date in the
     // current timezone.
     const dt = DateTime.fromISO(date).setZone("UTC");
-    let dateString;
+    let dateString: string;
     if (dt.hour === 0 && dt.minute === 0 && dt.second === 0) {
-      dateString = dt.toFormat("yyyy-MM-dd");
+      dateString = dt.toISO()!;
     } else {
-      dateString = dt.setZone().toFormat("yyyy-MM-dd");
+      dateString = dt.setZone().toISO()!;
     }
 
     if (date) {
-      markedDates[dateString] = {
+      markedDates[DateTime.fromISO(dateString).toFormat("yyyy-MM-dd")] = {
         selected: true,
         selectedColor: theme.primary,
       };


### PR DESCRIPTION
I think this is timezone related if you only pass in the yyyy-MM-dd format for the current date, it assumes UTC and not local time. However, marked dates cannot take an ISOString.