### PR TITLE
Add withConfirmation to Page

### DIFF
--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2873,6 +2873,9 @@ export interface PageProps {
   rightButtonOnClick?: () => void;
   children?: any;
   onError?: (error: Error, stack: any) => void;
+  withConfirmation?: boolean; // default false
+  confirmationText?: string;
+  confirmationHeading?: string;
 }
 
 export interface PogProps {

--- a/packages/ui/src/Page.tsx
+++ b/packages/ui/src/Page.tsx
@@ -21,10 +21,13 @@ export class Page extends React.Component<PageProps, {}> {
           <Box alignItems="center" display="block" justifyContent="center" paddingY={3}>
             <IconButton
               accessibilityLabel=""
+              confirmationHeading={this.props?.confirmationHeading}
+              confirmationText={this.props?.confirmationText}
               icon="chevron-left"
               iconColor="darkGray"
               prefix="fas"
               size="md"
+              withConfirmation={this.props?.withConfirmation ?? false}
               onClick={() => this.props.navigation.goBack()}
             />
           </Box>
@@ -33,10 +36,13 @@ export class Page extends React.Component<PageProps, {}> {
           <Box alignItems="center" display="block" justifyContent="center" paddingY={3}>
             <IconButton
               accessibilityLabel=""
+              confirmationHeading={this.props?.confirmationHeading}
+              confirmationText={this.props?.confirmationText}
               icon="times"
               iconColor="darkGray"
               prefix="fas"
               size="md"
+              withConfirmation={this.props?.withConfirmation ?? false}
               onClick={() => this.props.navigation.goBack()}
             />
           </Box>


### PR DESCRIPTION
At times we may want to warn users before navigating off page. i.e. unsaved work
Add withConfirmation Props to Page and prop drill to IconButton