### PR TITLE
Fix table pagination

### DIFF
--- a/packages/ui/src/Table.tsx
+++ b/packages/ui/src/Table.tsx
@@ -1,4 +1,4 @@
-import React, {Children, ReactElement} from "react";
+import React, {Children, ReactElement, useEffect} from "react";
 import {ScrollView} from "react-native";
 import {DimensionValue} from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 
@@ -45,6 +45,13 @@ export const Table = ({
   } else {
     width = "100%";
   }
+
+  // If propsPage changes in the parent, update the local page state.
+  useEffect(() => {
+    if (propsPage && propsPage !== page) {
+      setPage(propsPage);
+    }
+  }, [page, propsPage]);
 
   const shouldPaginate = more || page > 1;
 


### PR DESCRIPTION
## **User description**
If page was being passed into Table, it was only using the internal page, which wasn't being updated, so when you got to the end of the pages, the pagination went away.


___

## **Type**
Bug fix


___

## **Description**
- The PR addresses an issue where the pagination in the `Table` component was not updating correctly when the `propsPage` changed.
- A `useEffect` hook has been added to monitor changes in `propsPage` and update the local `page` state accordingly, ensuring that the pagination reflects the current page.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Table.tsx</strong><dd><code>Implement useEffect to Sync Pagination State</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/Table.tsx

<li>Added <code>useEffect</code> hook to update local page state when <code>propsPage</code> <br>changes.<br> <li> Imported <code>useEffect</code> from React.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/522/files#diff-0204065195fa86cdd186463e76fd6001178ea60456173a2c4b256590fbd0d017">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

