### PR TITLE
Fix crash around Luxon offsetNameShort

### DIFF
--- a/packages/ui/src/DateUtilities.test.ts
+++ b/packages/ui/src/DateUtilities.test.ts
@@ -1,8 +1,11 @@
 // Write a jest test for the DateUtilities functions
 
+import {DateTime} from "luxon";
+
 import {
   humanDate,
   humanDateAndTime,
+  offsetNameShort,
   printDate,
   printDateAndTime,
   printDateRange,
@@ -412,6 +415,83 @@ describe("DateUtilities", function () {
       expect(printSince("2019-12-23T11:00:00.000Z")).toBe("3 years ago");
       // print without ago
       expect(printSince("2019-12-23T11:00:00.000Z", {showAgo: false})).toBe("3 years");
+    });
+  });
+
+  describe("offsetNameShort", () => {
+    it("should return HST for Hawaii Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "Pacific/Honolulu"});
+      expect(offsetNameShort(date)).toBe("HST");
+    });
+
+    it("should return AKST for Alaska Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "America/Anchorage"});
+      expect(offsetNameShort(date)).toBe("AKST");
+    });
+
+    it("should return AKDT for Alaska Daylight Time", () => {
+      const date = DateTime.fromISO("2024-06-01T12:00:00", {zone: "America/Anchorage"});
+      expect(offsetNameShort(date)).toBe("AKDT");
+    });
+
+    it("should return PST for Pacific Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "America/Los_Angeles"});
+      expect(offsetNameShort(date)).toBe("PST");
+    });
+
+    it("should return PDT for Pacific Daylight Time", () => {
+      const date = DateTime.fromISO("2024-06-01T12:00:00", {zone: "America/Los_Angeles"});
+      expect(offsetNameShort(date)).toBe("PDT");
+    });
+
+    it("should return MST for Mountain Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "America/Denver"});
+      expect(offsetNameShort(date)).toBe("MST");
+    });
+
+    it("should return MDT for Mountain Daylight Time", () => {
+      const date = DateTime.fromISO("2024-06-01T12:00:00", {zone: "America/Denver"});
+      expect(offsetNameShort(date)).toBe("MDT");
+    });
+
+    it("should return MST for Arizona Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "America/Phoenix"});
+      expect(offsetNameShort(date)).toBe("MST");
+    });
+
+    it("should return MST for Arizona time even during daylight saving time", () => {
+      const date = DateTime.fromISO("2024-06-01T12:00:00", {zone: "America/Phoenix"});
+      expect(offsetNameShort(date)).toBe("MST");
+    });
+
+    it("should return CST for Central Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "America/Chicago"});
+      expect(offsetNameShort(date)).toBe("CST");
+    });
+
+    it("should return CDT for Central Daylight Time", () => {
+      const date = DateTime.fromISO("2024-06-01T12:00:00", {zone: "America/Chicago"});
+      expect(offsetNameShort(date)).toBe("CDT");
+    });
+
+    it("should return EST for Eastern Standard Time", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "America/New_York"});
+      expect(offsetNameShort(date)).toBe("EST");
+    });
+
+    it("should return EDT for Eastern Daylight Time", () => {
+      const date = DateTime.fromISO("2024-06-01T12:00:00", {zone: "America/New_York"});
+      expect(offsetNameShort(date)).toBe("EDT");
+    });
+
+    it("should return full zone name for other zones", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "Etc/GMT+2"});
+      expect(offsetNameShort(date)).toBe("Etc/GMT+2");
+    });
+
+    it("should return Unknown for an unrecognized timezone", () => {
+      const date = DateTime.fromISO("2024-01-01T12:00:00", {zone: "foo"});
+      expect(offsetNameShort(date)).toBe("Unknown");
     });
   });
 });

--- a/packages/ui/src/DateUtilities.tsx
+++ b/packages/ui/src/DateUtilities.tsx
@@ -82,6 +82,39 @@ export function humanDate(
   }
 }
 
+// Mapping zone names to US timezone abbreviations
+const useZoneMap: {[key: string]: {standard: string; daylight?: string}} = {
+  "Pacific/Honolulu": {standard: "HST"}, // Hawaii Standard Time, no DST
+  "America/Anchorage": {standard: "AKST", daylight: "AKDT"}, // Alaska Time
+  "America/Los_Angeles": {standard: "PST", daylight: "PDT"}, // Pacific Time
+  "America/Denver": {standard: "MST", daylight: "MDT"}, // Mountain Time
+  "America/Phoenix": {standard: "MST"}, // Arizona Mountain Standard Time, no DST
+  "America/Chicago": {standard: "CST", daylight: "CDT"}, // Central Time
+  "America/New_York": {standard: "EST", daylight: "EDT"}, // Eastern Time
+};
+
+export function offsetNameShort(date: DateTime): string {
+  // Get the zone name
+  const zoneName = date.zoneName;
+
+  if (!zoneName) {
+    return "Unknown";
+  }
+
+  // Determine if it's daylight savings time
+  const isDaylightSavings = date.isInDST;
+
+  // Find the abbreviation from the offset map
+  const timezone = useZoneMap[zoneName];
+
+  if (!timezone) {
+    return zoneName ?? "Unknown";
+  }
+
+  // Return the appropriate abbreviation based on daylight savings time
+  return isDaylightSavings && timezone.daylight ? timezone.daylight : timezone.standard;
+}
+
 // Prints a human friendly date and time, e.g. "Tomorrow 9:00 AM", "Yesterday 9:00 AM", "Monday
 // 9:00 AM", "June 19 9:00 AM", "December 25, 2022 9:00 AM".
 export function humanDateAndTime(
@@ -97,7 +130,7 @@ export function humanDateAndTime(
   // This should maybe use printTime()
   let time = clonedDate.toFormat("h:mm a");
   if (showTimezone) {
-    time += ` ${clonedDate.offsetNameShort}`;
+    time += ` ${offsetNameShort(clonedDate)}`;
   }
   if (isTomorrow(date, {timezone})) {
     return `Tomorrow ${time}`;
@@ -243,7 +276,7 @@ export function printDateAndTime(
   }
   let dateString = clonedDate.toLocaleString(DateTime.DATETIME_SHORT);
   if (showTimezone) {
-    dateString += ` ${clonedDate.offsetNameShort}`;
+    dateString += ` ${offsetNameShort(clonedDate)}`;
   }
   return dateString;
 }


### PR DESCRIPTION
### **User description**
Apparently this is broken in Hermes, so write a temporary fix. Unfortunately this doesn't work well outside the US.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implemented the `offsetNameShort` function to handle timezone abbreviations based on the provided DateTime object.
- Added a new mapping dictionary `useZoneMap` to translate zone names to their respective US timezone abbreviations.
- Integrated the `offsetNameShort` function into `humanDateAndTime` and `printDateAndTime` functions to display timezone abbreviations.
- Added extensive tests for `offsetNameShort` to ensure correct abbreviations for various time zones and handling of unrecognized zones.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateUtilities.test.ts</strong><dd><code>Add Tests for `offsetNameShort` Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/DateUtilities.test.ts

<li>Added comprehensive test cases for the <code>offsetNameShort</code> function.<br> <li> Tests cover various US time zones and edge cases like unrecognized <br>time zones.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/543/files#diff-f6d92a020982929e26f8f8e2629d160241d820897af808488e89087072676bb5">+80/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateUtilities.tsx</strong><dd><code>Implement and Integrate `offsetNameShort` Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/DateUtilities.tsx

<li>Implemented <code>offsetNameShort</code> function to map time zone names to US <br>timezone abbreviations.<br> <li> Adjusted existing functions to use <code>offsetNameShort</code> for timezone <br>display.<br> <li> Added a mapping dictionary <code>useZoneMap</code> for standard and daylight time <br>abbreviations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/543/files#diff-8a8e71df82a067f1d236e7099ae5a205dbbd4d672eb12974ff0b426ed20113db">+35/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

