### PR TITLE
Fix time-only formatting error for mobile

### DIFF
--- a/packages/ui/src/DateUtilities.tsx
+++ b/packages/ui/src/DateUtilities.tsx
@@ -95,9 +95,15 @@ export function humanDateAndTime(
     throw new Error(`humanDateAndTime: ${error.message}`);
   }
   // This should maybe use printTime()
-  let time = clonedDate.toFormat("h:mm a");
+  let time: string = "";
   if (showTimezone) {
-    time += ` ${clonedDate.offsetNameShort}`;
+    time = clonedDate.toLocaleString({
+      timeZoneName: "short",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } else {
+    time = clonedDate.toFormat("h:mm a");
   }
   if (isTomorrow(date, {timezone})) {
     return `Tomorrow ${time}`;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a time-only formatting error for mobile devices in the `humanDateAndTime` function.
- Updated the time formatting logic to use `toLocaleString` with `timeZoneName` and `hour`/`minute` options when `showTimezone` is true.
- Ensured consistent time display with or without timezone information.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateUtilities.tsx</strong><dd><code>Fix time-only formatting error for mobile in <code>humanDateAndTime</code> function</code></dd></summary>
<hr>
      
packages/ui/src/DateUtilities.tsx

<li>Fixed time-only formatting error for mobile by adjusting the time <br>formatting logic.<br> <li> Updated the <code>humanDateAndTime</code> function to use <code>toLocaleString</code> for time <br>formatting when <code>showTimezone</code> is true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/550/files#diff-8a8e71df82a067f1d236e7099ae5a205dbbd4d672eb12974ff0b426ed20113db">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

