### PR TITLE
Fix tap to edit

### DIFF
--- a/packages/ui-demo/package.json
+++ b/packages/ui-demo/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "expo-crypto": "~13.0.2",
-    "ferns-ui": "0.46.1",
+    "ferns-ui": "*",
     "react": "18.2.0",
     "stream-browserify": "^3.0.0"
   },

--- a/packages/ui-demo/src/TapToEdit.stories.tsx
+++ b/packages/ui-demo/src/TapToEdit.stories.tsx
@@ -27,7 +27,7 @@ const TapStory = (): ReactElement => {
   });
   const [url, setURL] = useState("https://en.wikipedia.org/wiki/React_Native#Implementation");
   return (
-    <Box direction="column" display="flex" height="100%" width="100%">
+    <Box direction="column" display="flex" height="100%" scroll width="100%">
       <TapToEdit
         key="text"
         name="text"
@@ -42,7 +42,7 @@ const TapStory = (): ReactElement => {
         }}
       />
       <TapToEdit
-        key="text"
+        key="texttooltip"
         name="text"
         openApiField="name"
         openApiModel="users"
@@ -56,7 +56,7 @@ const TapStory = (): ReactElement => {
         }}
       />
       <TapToEdit
-        key="text"
+        key="textarea"
         name="textarea"
         openApiField="name"
         openApiModel="users"
@@ -196,14 +196,14 @@ export const TapToEditStories = {
   stories: {
     TapToEdit() {
       return (
-        <Box color="white" width={300}>
+        <Box color="white" height="100%" width={300}>
           <TapStory />
         </Box>
       );
     },
     TapToEditWithOpenAPI() {
       return (
-        <Box color="white" width={300}>
+        <Box color="white" height="100%" width={300}>
           <OpenAPIProvider specUrl="http://localhost:3000/openapi.json">
             <TapStory />
           </OpenAPIProvider>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -22,7 +22,7 @@ const TapToEditTitle = ({
   description?: string;
 }): ReactElement => {
   return (
-    <Box flex="grow" marginBottom={2}>
+    <Box flex="grow" justifyContent="center">
       <Text weight="bold">{title}:</Text>
       {Boolean(description && !showDescriptionAsTooltip && !onlyShowDescriptionWhileEditing) && (
         <Text color="gray" size="sm">
@@ -232,7 +232,11 @@ export const TapToEdit = ({
           />
         )}
         <Box direction="row" flex="grow" justifyContent="end" marginLeft={2}>
-          <Box flex="grow" justifyContent="start" onClick={isClickable ? openLink : undefined}>
+          <Box
+            justifyContent="start"
+            marginLeft={fieldProps?.type === "textarea" ? 4 : 0}
+            onClick={isClickable ? openLink : undefined}
+          >
             <Text
               align={fieldProps?.type === "textarea" ? "left" : "right"}
               underline={isClickable}


### PR DESCRIPTION
### **User description**
We had too many flexbox's trying to grow, so the right side took over.

![image](https://github.com/FlourishHealth/ferns-ui/assets/204714/e183ab73-6e4b-471e-b18a-b3c8ac164feb)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved layout handling in `TapToEdit` stories by adding `scroll` property and ensuring consistent height.
- Adjusted `Box` component properties in `TapToEdit` for better alignment and spacing.
- Updated `ferns-ui` dependency version to a wildcard in `package.json`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.stories.tsx</strong><dd><code>Improve layout and key handling in TapToEdit stories.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui-demo/src/TapToEdit.stories.tsx

<li>Added <code>scroll</code> property to <code>Box</code> component for better layout handling.<br> <li> Changed <code>key</code> values for <code>TapToEdit</code> components to unique identifiers.<br> <li> Modified <code>Box</code> components to have <code>height="100%"</code> for consistent height.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/552/files#diff-7a79b3231fd2a0ddff4e1b32077ddc0d23423cf12a3c35f78fb5c100ab994dd8">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Adjust Box component properties for better alignment.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/TapToEdit.tsx

<li>Adjusted <code>Box</code> component properties for better alignment and spacing.<br> <li> Added conditional margin and alignment based on <code>fieldProps.type</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/552/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update ferns-ui dependency version.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui-demo/package.json

- Updated `ferns-ui` dependency version to a wildcard.



</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/552/files#diff-d8653eb2411915d70d290a10ef6fda58226fa82e6144ea01dc820e1048710a6e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

