### PR TITLE
Fix drawer overflow scroll on web

### DIFF
--- a/packages/ui/src/SideDrawer.tsx
+++ b/packages/ui/src/SideDrawer.tsx
@@ -2,15 +2,15 @@ import React, {ReactElement} from "react";
 import {Platform, SafeAreaView, StyleProp, ViewStyle} from "react-native";
 import {Drawer} from "react-native-drawer-layout";
 
+import {Box} from "./Box";
 import {SideDrawerProps} from "./Common";
-import {isMobileDevice} from "./MediaQuery";
 
 const DEFAULT_STYLES: StyleProp<ViewStyle> = {
   width: Platform.OS === "web" ? "40%" : "95%",
+  height: "100%",
   backgroundColor: "lightgray",
   borderWidth: 1,
   borderColor: "gray",
-  overflow: isMobileDevice() ? undefined : "scroll",
 };
 
 export const SideDrawer = ({
@@ -27,16 +27,18 @@ export const SideDrawer = ({
     return <SafeAreaView>{renderContent()}</SafeAreaView>;
   };
   return (
-    <Drawer
-      drawerPosition={position}
-      drawerStyle={[DEFAULT_STYLES, drawerStyles]}
-      drawerType={drawerType}
-      open={isOpen}
-      renderDrawerContent={renderDrawerContent}
-      onClose={onClose}
-      onOpen={onOpen}
-    >
-      {children}
-    </Drawer>
+    <Box height="100%" overflow="hidden" width="100%">
+      <Drawer
+        drawerPosition={position}
+        drawerStyle={[DEFAULT_STYLES, drawerStyles]}
+        drawerType={drawerType}
+        open={isOpen}
+        renderDrawerContent={renderDrawerContent}
+        onClose={onClose}
+        onOpen={onOpen}
+      >
+        {children}
+      </Drawer>
+    </Box>
   );
 };


### PR DESCRIPTION
The most recent update to Drawer made it so if you scrolled horizontally, you'd see the drawer. It should be hidden on scroll, so by wrapping in overflow: hidden, it does just that.

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Wrapped the `Drawer` component with a `Box` component to handle overflow issues more effectively on web platforms.
- Set the `height` property to `100%` in `DEFAULT_STYLES` to ensure the drawer takes up the full height.
- Removed the `overflow` property from `DEFAULT_STYLES` to prevent unwanted scrolling behavior.
- Adjusted the drawer layout to ensure it behaves correctly across different platforms, particularly on the web.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SideDrawer.tsx</strong><dd><code>Fix and enhance drawer overflow handling on web</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/SideDrawer.tsx

<li>Added a <code>Box</code> component to wrap the <code>Drawer</code> for better overflow handling.<br> <li> Set <code>height</code> to <code>100%</code> in <code>DEFAULT_STYLES</code>.<br> <li> Removed <code>overflow</code> property from <code>DEFAULT_STYLES</code>.<br> <li> Adjusted the drawer layout to prevent overflow issues on web.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/554/files#diff-ea1613097d2a23d0cbff151e8706c13e33dad7f6c85c527fce32e51d6b9a5068">+15/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

