### PR TITLE
Fix textarea tap to edit again

### DIFF
--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -21,7 +21,7 @@ const TapToEditTitle = ({
   title: string;
   description?: string;
 }): ReactElement => {
-  return (
+  const Title = (
     <Box flex="grow" justifyContent="center">
       <Text weight="bold">{title}:</Text>
       {Boolean(description && !showDescriptionAsTooltip && !onlyShowDescriptionWhileEditing) && (
@@ -31,6 +31,15 @@ const TapToEditTitle = ({
       )}
     </Box>
   );
+  if (showDescriptionAsTooltip) {
+    return (
+      <Tooltip idealDirection="top" text={description}>
+        {Title}
+      </Tooltip>
+    );
+  } else {
+    return Title;
+  }
 };
 
 export function formatAddress(address: any, asString = false): string {
@@ -214,42 +223,35 @@ export const TapToEdit = ({
         width="100%"
         {...rowBoxProps}
       >
-        {showDescriptionAsTooltip ? (
-          <Tooltip idealDirection="top" text={description}>
-            <TapToEditTitle
-              description={description}
-              onlyShowDescriptionWhileEditing={onlyShowDescriptionWhileEditing}
-              showDescriptionAsTooltip={showDescriptionAsTooltip}
-              title={title}
-            />
-          </Tooltip>
-        ) : (
+        <Box direction="row" width="100%">
           <TapToEditTitle
             description={description}
             onlyShowDescriptionWhileEditing={onlyShowDescriptionWhileEditing}
             showDescriptionAsTooltip={showDescriptionAsTooltip}
             title={title}
           />
-        )}
-        <Box direction="row" flex="grow" justifyContent="end" marginLeft={2}>
-          <Box
-            justifyContent="start"
-            marginLeft={fieldProps?.type === "textarea" ? 4 : 0}
-            onClick={isClickable ? openLink : undefined}
-          >
-            <Text
-              align={fieldProps?.type === "textarea" ? "left" : "right"}
-              underline={isClickable}
-            >
+          <Box direction="row" flex="grow" justifyContent="end" marginLeft={2}>
+            <Box justifyContent="start" onClick={isClickable ? openLink : undefined}>
+              {Boolean(fieldProps?.type !== "textarea") && (
+                <Text align="right" underline={isClickable}>
+                  {displayValue}
+                </Text>
+              )}
+            </Box>
+            {editable && (
+              <Box marginLeft={2} width={16} onClick={(): void => setEditing(true)}>
+                <Icon color="darkGray" name="edit" prefix="far" size="md" />
+              </Box>
+            )}
+          </Box>
+        </Box>
+        {fieldProps?.type === "textarea" && (
+          <Box marginTop={2} paddingY={2} width="100%">
+            <Text align="left" underline={isClickable}>
               {displayValue}
             </Text>
           </Box>
-          {editable && (
-            <Box alignSelf="end" marginLeft={2} width={16} onClick={(): void => setEditing(true)}>
-              <Icon color="darkGray" name="edit" prefix="far" size="md" />
-            </Box>
-          )}
-        </Box>
+        )}
       </Box>
     );
   }


### PR DESCRIPTION
### **User description**
The last fix led to some overflow on the left and the edit icon rendering oddly.

Mobile:
![image](https://github.com/FlourishHealth/ferns-ui/assets/204714/1a63a186-a639-428e-a271-944efa701208)


Web:
![image](https://github.com/FlourishHealth/ferns-ui/assets/204714/42a064fb-3557-45b4-b1e6-96da99133074)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored the `TapToEditTitle` component to conditionally wrap the title in a tooltip based on the `showDescriptionAsTooltip` prop.
- Simplified the layout logic in the `TapToEdit` component to fix overflow and alignment issues.
- Corrected the rendering of the edit icon and textarea to ensure proper display on both mobile and web platforms.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Refactor and fix layout issues in TapToEdit component</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/TapToEdit.tsx

<li>Refactored <code>TapToEditTitle</code> to conditionally wrap title in a tooltip.<br> <li> Simplified and corrected layout issues for <code>TapToEdit</code> component.<br> <li> Fixed overflow and alignment issues for textarea and edit icon.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/565/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+30/-28</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

