### PR TITLE
Add web drawer scroll

### DIFF
--- a/packages/ui/src/SideDrawer.tsx
+++ b/packages/ui/src/SideDrawer.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement} from "react";
+import React, {ReactElement, useCallback} from "react";
 import {Platform, SafeAreaView, StyleProp, ViewStyle} from "react-native";
 import {Drawer} from "react-native-drawer-layout";
 
@@ -12,6 +12,14 @@ const DEFAULT_STYLES: StyleProp<ViewStyle> = {
   borderColor: "gray",
 };
 
+const addWebScroll = (isOpen: boolean): ViewStyle => {
+  if (Platform.OS === "web") {
+    return {display: isOpen ? "flex" : "none", overflow: "scroll"};
+  } else {
+    return {};
+  }
+};
+
 export const SideDrawer = ({
   position = "left",
   isOpen,
@@ -22,22 +30,14 @@ export const SideDrawer = ({
   children,
   drawerStyles = {},
 }: SideDrawerProps): ReactElement => {
-  const renderDrawerContent = (): ReactElement => {
+  const renderDrawerContent = useCallback((): ReactElement => {
     return <SafeAreaView>{renderContent()}</SafeAreaView>;
-  };
-
-  const addWebScroll = (): any => {
-    if (Platform.OS === "web") {
-      return {display: isOpen ? "flex" : "none", overflow: "scroll"};
-    } else {
-      return {};
-    }
-  };
+  }, [renderContent]);
 
   return (
     <Drawer
       drawerPosition={position}
-      drawerStyle={[DEFAULT_STYLES, drawerStyles, addWebScroll()]}
+      drawerStyle={[DEFAULT_STYLES, drawerStyles, addWebScroll(isOpen)]}
       drawerType={drawerType}
       open={isOpen}
       renderDrawerContent={renderDrawerContent}

--- a/packages/ui/src/SideDrawer.tsx
+++ b/packages/ui/src/SideDrawer.tsx
@@ -7,7 +7,7 @@ import {SideDrawerProps} from "./Common";
 const DEFAULT_STYLES: StyleProp<ViewStyle> = {
   width: Platform.OS === "web" ? "40%" : "95%",
   height: "100%",
-  backgroundColor: "green",
+  backgroundColor: "lightgray",
   borderWidth: 1,
   borderColor: "gray",
 };

--- a/packages/ui/src/SideDrawer.tsx
+++ b/packages/ui/src/SideDrawer.tsx
@@ -2,13 +2,12 @@ import React, {ReactElement} from "react";
 import {Platform, SafeAreaView, StyleProp, ViewStyle} from "react-native";
 import {Drawer} from "react-native-drawer-layout";
 
-import {Box} from "./Box";
 import {SideDrawerProps} from "./Common";
 
 const DEFAULT_STYLES: StyleProp<ViewStyle> = {
   width: Platform.OS === "web" ? "40%" : "95%",
   height: "100%",
-  backgroundColor: "lightgray",
+  backgroundColor: "green",
   borderWidth: 1,
   borderColor: "gray",
 };
@@ -26,19 +25,26 @@ export const SideDrawer = ({
   const renderDrawerContent = (): ReactElement => {
     return <SafeAreaView>{renderContent()}</SafeAreaView>;
   };
+
+  const addWebScroll = (): any => {
+    if (Platform.OS === "web") {
+      return {display: isOpen ? "flex" : "none", overflow: "scroll"};
+    } else {
+      return {};
+    }
+  };
+
   return (
-    <Box height="100%" overflow="hidden" width="100%">
-      <Drawer
-        drawerPosition={position}
-        drawerStyle={[DEFAULT_STYLES, drawerStyles]}
-        drawerType={drawerType}
-        open={isOpen}
-        renderDrawerContent={renderDrawerContent}
-        onClose={onClose}
-        onOpen={onOpen}
-      >
-        {children}
-      </Drawer>
-    </Box>
+    <Drawer
+      drawerPosition={position}
+      drawerStyle={[DEFAULT_STYLES, drawerStyles, addWebScroll()]}
+      drawerType={drawerType}
+      open={isOpen}
+      renderDrawerContent={renderDrawerContent}
+      onClose={onClose}
+      onOpen={onOpen}
+    >
+      {children}
+    </Drawer>
   );
 };


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a function `addWebScroll` to handle scroll and overflow specifically for the web platform in the `SideDrawer` component.
- Modified the `drawerStyle` prop to include the new scroll handling styles for web.
- Removed the `Box` component wrapper around the `Drawer`, simplifying the component structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SideDrawer.tsx</strong><dd><code>Add scroll and overflow handling for web in SideDrawer component</code></dd></summary>
<hr>
      
packages/ui/src/SideDrawer.tsx

<li>Added a function <code>addWebScroll</code> to handle scroll and overflow for web <br>platform.<br> <li> Modified <code>drawerStyle</code> to include the new scroll handling styles for <br>web.<br> <li> Removed the <code>Box</code> component wrapper around the <code>Drawer</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/567/files#diff-ea1613097d2a23d0cbff151e8706c13e33dad7f6c85c527fce32e51d6b9a5068">+20/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

