### PR TITLE
TapToEdit - add useEffect for initialValue handling

### DIFF
--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -3122,6 +3122,8 @@ export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   showDescriptionAsTooltip?: boolean;
   // Default true. If false, description is shown below the value always.
   onlyShowDescriptionWhileEditing?: boolean;
+  // For persisting or reseting editing state from outside the component
+  instanceId?: string;
 }
 
 export interface APIError {

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -3122,8 +3122,6 @@ export interface TapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   showDescriptionAsTooltip?: boolean;
   // Default true. If false, description is shown below the value always.
   onlyShowDescriptionWhileEditing?: boolean;
-  // For persisting or reseting editing state from outside the component
-  instanceId?: string;
 }
 
 export interface APIError {

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useState} from "react";
+import React, {ReactElement, useEffect, useRef, useState} from "react";
 import {Linking} from "react-native";
 
 import {Box} from "./Box";
@@ -97,12 +97,21 @@ export const TapToEdit = ({
   description: propsDescription,
   showDescriptionAsTooltip = false,
   onlyShowDescriptionWhileEditing = true,
+  instanceId,
   ...fieldProps
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
   const [initialValue] = useState(value);
   const description: string | undefined = propsDescription;
+  const prevInstanceId = useRef<string | undefined>(instanceId);
 
+  // reset editing state when instanceId changes
+  useEffect(() => {
+    if (instanceId !== prevInstanceId.current && !isEditing) {
+      setEditing(false);
+      prevInstanceId.current = instanceId;
+    }
+  }, [instanceId, isEditing]);
   if (editable && !setValue) {
     throw new Error("setValue is required if editable is true");
   }

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useEffect, useRef, useState} from "react";
+import React, {ReactElement, useEffect, useState} from "react";
 import {Linking} from "react-native";
 
 import {Box} from "./Box";
@@ -97,21 +97,18 @@ export const TapToEdit = ({
   description: propsDescription,
   showDescriptionAsTooltip = false,
   onlyShowDescriptionWhileEditing = true,
-  instanceId,
   ...fieldProps
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
-  const [initialValue] = useState(value);
+  const [initialValue, setInitialValue] = useState();
   const description: string | undefined = propsDescription;
-  const prevInstanceId = useRef<string | undefined>(instanceId);
-
-  // reset editing state when instanceId changes
+  // setInitialValue is called after initial render to handle the case where the value is updated
   useEffect(() => {
-    if (instanceId !== prevInstanceId.current && !isEditing) {
-      setEditing(false);
-      prevInstanceId.current = instanceId;
-    }
-  }, [instanceId, isEditing]);
+    setInitialValue(value);
+    // do not update if value changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (editable && !setValue) {
     throw new Error("setValue is required if editable is true");
   }
@@ -144,6 +141,7 @@ export const TapToEdit = ({
                 if (!onSave) {
                   console.error("No onSave provided for editable TapToEdit");
                 } else {
+                  setInitialValue(value);
                   await onSave(value);
                 }
                 setEditing(false);


### PR DESCRIPTION
### **User description**
Issue:
https://github.com/orgs/FlourishHealth/projects/1/views/17?pane=issue&itemId=45864486

add useEffect to handle initial value and update initial value on save


___

### **PR Type**
Enhancement


___

### **Description**
- Added `useEffect` to set the initial value after the initial render in `TapToEdit`.
- Updated `initialValue` state when the `onSave` function is called.
- Imported `useEffect` from React to manage side effects.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Add `useEffect` for initial value handling in TapToEdit</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/TapToEdit.tsx

<li>Added <code>useEffect</code> to handle initial value setting.<br> <li> Updated <code>initialValue</code> state on save.<br> <li> Imported <code>useEffect</code> from React.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/576/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

