### PR TITLE
fix 12AM hour bug

### DIFF
--- a/packages/ui/src/DateTimeActionSheet.tsx
+++ b/packages/ui/src/DateTimeActionSheet.tsx
@@ -344,7 +344,17 @@ export const DateTimeActionSheet = ({
 
   // Note: do not call this if waiting on a state change.
   const sendOnChange = () => {
-    const militaryHour = amPm === "pm" && hour !== 12 ? Number(hour) + 12 : Number(hour);
+    // hour is already correct for all AM hours except 12(AM)
+    let militaryHour = hour;
+
+    // 12AM should be 0
+    if (amPm === "am" && hour === 12) {
+      militaryHour = 0;
+    }
+    // all PM hours except 12PM (already correct) should add 12
+    else if (amPm === "pm" && hour !== 12) {
+      militaryHour = Number(hour) + 12;
+    }
 
     if (mode === "date") {
       const v = DateTime.fromISO(date)


### PR DESCRIPTION
### **User description**
Logic for setting hour was missing 12AM hour condition


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in `DateTimeActionSheet` where 12AM was not correctly converted to 0 in military time.
- Adjusted the logic to ensure PM hours, except 12PM, are correctly converted by adding 12.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimeActionSheet.tsx</strong><dd><code>Fix 12AM hour conversion bug in DateTimeActionSheet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/ui/src/DateTimeActionSheet.tsx

<li>Added logic to handle 12AM hour conversion to 0.<br> <li> Adjusted PM hour conversion logic to exclude 12PM.<br>


</details>
    

  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/577/files#diff-08c08b9b5a16174d1bf6bc005f080e8b79409a32f1fdc31c224bce72dc5751ca">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

