### PR TITLE
Add Box accessibility requirements if onClick is provided

### DIFF
--- a/packages/ui/src/Box.tsx
+++ b/packages/ui/src/Box.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, {useContext, useImperativeHandle} from "react";
 import {
+  AccessibilityProps,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -251,8 +252,9 @@ export const Box = React.forwardRef((props: BoxProps, ref) => {
   if (props.onClick) {
     box = (
       <Pressable
+        accessibilityHint={(props as AccessibilityProps).accessibilityHint}
+        accessibilityLabel={(props as AccessibilityProps).accessibilityLabel}
         accessibilityRole="button"
-        // accessibilityRole="button"
         style={propsToStyle()}
         testID={props.testID ? `${props.testID}-clickable` : undefined}
         onLayout={props.onLayout}

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -422,7 +422,12 @@ export interface LayerProps {
   children: ReactChildren;
 }
 
-export interface BoxProps {
+type AccessibilityProps = {
+  accessibilityLabel: string;
+  accessibilityHint: string;
+};
+
+export interface BoxPropsBase {
   alignContent?: AlignContent;
   alignItems?: AlignItems;
   alignSelf?: AlignSelf;
@@ -524,6 +529,10 @@ export interface BoxProps {
   onLayout?: (event: LayoutChangeEvent) => void;
   testID?: string;
 }
+
+// If onClick is provided, add accessibility props.
+export type BoxProps = BoxPropsBase &
+  (BoxPropsBase extends {onClick: () => void} ? AccessibilityProps : {});
 
 export type BoxColor = SurfaceColor | "transparent";
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `accessibilityHint` and `accessibilityLabel` props to the `Pressable` component within `Box` when `onClick` is provided to improve accessibility.
- Introduced a new `AccessibilityProps` type in `Common.ts`.
- Updated `BoxProps` to conditionally include `AccessibilityProps` if `onClick` is provided, ensuring that accessibility requirements are met.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Box.tsx</strong><dd><code>Add accessibility props to Pressable component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Box.tsx

<li>Added <code>accessibilityHint</code> and <code>accessibilityLabel</code> props to <code>Pressable</code> <br>component when <code>onClick</code> is provided.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/621/files#diff-c573fcf572c93f7ebfb7b3178345a9e42987fae60e28d59edf508519e820471c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Common.ts</strong><dd><code>Update BoxProps to include AccessibilityProps conditionally</code></dd></summary>
<hr>

packages/ui/src/Common.ts

<li>Introduced <code>AccessibilityProps</code> type.<br> <li> Updated <code>BoxProps</code> to conditionally include <code>AccessibilityProps</code> when <br><code>onClick</code> is provided.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/621/files#diff-538e93b553971318d69ff6fff2ac103f295c4922e24bbe61c30897baa463bba1">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

