### PR TITLE
Allow custom colors for Badge, other fixes

### DIFF
--- a/apps/demo/stories/Accordion.stories.tsx
+++ b/apps/demo/stories/Accordion.stories.tsx
@@ -34,7 +34,7 @@ export const AccordionDevDemo = () => {
         <Accordion
           includeInfoModal
           infoModalChildren={<InfoChild />}
-          infoModalSubTitle="Info Modal Sub title"
+          infoModalSubtitle="Info Modal Subtitle"
           infoModalTitle="Info Modal Title"
           title="Accordion Title"
         >

--- a/apps/demo/stories/Badge.stories.tsx
+++ b/apps/demo/stories/Badge.stories.tsx
@@ -6,18 +6,20 @@ import {StorybookContainer} from "./StorybookContainer";
 export const BadgeDemo = (props: Partial<BadgeProps>) => {
   return (
     <Box alignItems="center" justifyContent="center">
-      <Badge iconName="check" status="info" value="Default" variant="text" {...props} />
+      <Badge iconName="check" status="info" value="Default" {...props} />
     </Box>
   );
 };
 
-function badgeLine(text: string, badgeProps: any) {
+function badgeLine(text: string, badgeProps: Partial<BadgeProps>) {
   return (
     <Box direction="row" paddingY={2}>
-      <Box marginRight={2}>
+      <Box width={100}>
+        <Badge iconName="check" {...badgeProps} />
+      </Box>
+      <Box>
         <Text>{text}</Text>
       </Box>
-      <Badge iconName="check" {...badgeProps} />
     </Box>
   );
 }
@@ -27,30 +29,30 @@ export const BadgeStories = () => {
     <StorybookContainer>
       <Box direction="column">
         {badgeLine("Default", {value: "Default"})}
-        {badgeLine("Default Secondary", {variant: "iconOnly"})}
-        {badgeLine("Default", {variant: "numberOnly", value: "10"})}
-        {badgeLine("Default Secondary", {secondary: true, value: "Default"})}
-        {badgeLine("Default", {
+        {badgeLine("Icon Only", {variant: "iconOnly"})}
+        {badgeLine("Number Only", {variant: "numberOnly", value: "10"})}
+        {badgeLine("Secondary Default", {secondary: true, value: "Default"})}
+        {badgeLine("Secondary Icon Only", {
           secondary: true,
           variant: "iconOnly",
         })}
-        {badgeLine("Default Secondary", {
+        {badgeLine("Secondary Number Only", {
           secondary: true,
           variant: "numberOnly",
           value: "5",
         })}
 
         {badgeLine("Error", {value: "Failed", status: "error"})}
-        {badgeLine("Error Secondary", {variant: "iconOnly", value: "Failed", status: "error"})}
-        {badgeLine("Error", {variant: "numberOnly", value: "10", status: "error"})}
+        {badgeLine("Error Icon Only", {variant: "iconOnly", value: "Failed", status: "error"})}
+        {badgeLine("Error Number Only", {variant: "numberOnly", value: "10", status: "error"})}
         {badgeLine("Error Secondary", {secondary: true, value: "Failed", status: "error"})}
-        {badgeLine("Error", {
+        {badgeLine("Error Secondary Icon Only", {
           secondary: true,
           variant: "iconOnly",
           value: "Failed",
           status: "error",
         })}
-        {badgeLine("Error Secondary", {
+        {badgeLine("Error Secondary Number Only", {
           secondary: true,
           variant: "numberOnly",
           value: "5",
@@ -58,52 +60,99 @@ export const BadgeStories = () => {
         })}
 
         {badgeLine("Warning", {value: "Failed", status: "warning"})}
-        {badgeLine("Warning Secondary", {variant: "iconOnly", value: "Failed", status: "warning"})}
-        {badgeLine("Warning", {variant: "numberOnly", value: "10", status: "warning"})}
+        {badgeLine("Warning Icon Only", {variant: "iconOnly", value: "Failed", status: "warning"})}
+        {badgeLine("Warning Number Only", {variant: "numberOnly", value: "10", status: "warning"})}
         {badgeLine("Warning Secondary", {secondary: true, value: "Failed", status: "warning"})}
-        {badgeLine("Warning", {
+        {badgeLine("Warning Secondary Icon Only", {
           secondary: true,
           variant: "iconOnly",
           value: "Failed",
           status: "warning",
         })}
-        {badgeLine("Warning Secondary", {
+        {badgeLine("Warning Secondary Number Only", {
           secondary: true,
           variant: "numberOnly",
           value: "5",
           status: "warning",
         })}
         {badgeLine("Success", {value: "Failed", status: "success"})}
-        {badgeLine("Success Secondary", {variant: "iconOnly", value: "Failed", status: "success"})}
-        {badgeLine("Success", {variant: "numberOnly", value: "10", status: "success"})}
+        {badgeLine("Success Icon Only", {variant: "iconOnly", value: "Failed", status: "success"})}
+        {badgeLine("Success Number Only", {variant: "numberOnly", value: "10", status: "success"})}
         {badgeLine("Success Secondary", {secondary: true, value: "Failed", status: "success"})}
-        {badgeLine("Success", {
+        {badgeLine("Success Secondary Icon Only", {
           secondary: true,
           variant: "iconOnly",
           value: "Failed",
           status: "success",
         })}
-        {badgeLine("Success Secondary", {
+        {badgeLine("Success Secondary Number Only", {
           secondary: true,
           variant: "numberOnly",
           value: "5",
           status: "success",
         })}
         {badgeLine("Neutral", {value: "Failed", status: "neutral"})}
-        {badgeLine("Neutral Secondary", {variant: "iconOnly", value: "Failed", status: "neutral"})}
-        {badgeLine("Neutral", {variant: "numberOnly", value: "10", status: "neutral"})}
+        {badgeLine("Neutral Icon Only", {variant: "iconOnly", value: "Failed", status: "neutral"})}
+        {badgeLine("Neutral Number Only", {variant: "numberOnly", value: "10", status: "neutral"})}
         {badgeLine("Neutral Secondary", {secondary: true, value: "Failed", status: "neutral"})}
-        {badgeLine("Neutral", {
+        {badgeLine("Neutral Secondary Icon Only", {
           secondary: true,
           variant: "iconOnly",
           value: "Failed",
           status: "neutral",
         })}
-        {badgeLine("Neutral Secondary", {
+        {badgeLine("Neutral Secondary Nubmer Only", {
           secondary: true,
           variant: "numberOnly",
           value: "5",
           status: "neutral",
+        })}
+
+        {badgeLine("Custom", {
+          value: "Custom",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+        })}
+        {badgeLine("Custom Icon Only", {
+          variant: "iconOnly",
+          value: "Failed",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+        })}
+        {badgeLine("Custom Number Only", {
+          variant: "numberOnly",
+          value: "10",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+        })}
+        {badgeLine("Custom Secondary", {
+          secondary: true,
+          value: "Failed",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+        })}
+        {badgeLine("Custom Secondary Icon Only", {
+          secondary: true,
+          variant: "iconOnly",
+          value: "Failed",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+        })}
+        {badgeLine("Custom Secondary Nubmer Only", {
+          secondary: true,
+          variant: "numberOnly",
+          value: "5",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+        })}
+        {badgeLine("Custom Secondary Font And Border", {
+          secondary: true,
+          value: "Very Custom!",
+          status: "custom",
+          customBackgroundColor: "#FFA6C9",
+          customBorderColor: "#6600CC",
+          customTextColor: "#6600CC",
+          customIconColor: "success",
         })}
       </Box>
     </StorybookContainer>

--- a/apps/demo/stories/Badge.stories.tsx
+++ b/apps/demo/stories/Badge.stories.tsx
@@ -112,6 +112,7 @@ export const BadgeStories = () => {
           value: "Custom",
           status: "custom",
           customBackgroundColor: "#FFA6C9",
+          customTextColor: "#FFFFFF",
         })}
         {badgeLine("Custom Icon Only", {
           variant: "iconOnly",
@@ -153,6 +154,7 @@ export const BadgeStories = () => {
           customBorderColor: "#6600CC",
           customTextColor: "#6600CC",
           customIconColor: "success",
+          customIconName: "user-astronaut",
         })}
       </Box>
     </StorybookContainer>

--- a/apps/demo/stories/Modal.stories.tsx
+++ b/apps/demo/stories/Modal.stories.tsx
@@ -11,7 +11,7 @@ export const ModalDemo = (props: Partial<ModalProps>) => {
         primaryButtonOnClick={() => setShowModal(false)}
         primaryButtonText="Accept"
         secondaryButtonOnClick={() => setShowModal(false)}
-        subTitle="Sub heading"
+        subtitle="Sub heading"
         text="This is the text of the modal."
         title="Demo modal"
         visible={showModal}
@@ -52,7 +52,7 @@ export const Modals = () => {
         secondaryButtonOnClick={() => {}}
         secondaryButtonText={modalToShow === "secondary" ? "Secondary" : undefined}
         size={size as "sm" | "md" | "lg"}
-        subTitle="Sub heading"
+        subtitle="Sub heading"
         text="This is the text of the modal."
         title={`${modalToShow} modal`}
         visible={

--- a/packages/ui/src/Accordion.tsx
+++ b/packages/ui/src/Accordion.tsx
@@ -1,25 +1,32 @@
 import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
-import React, {FC, useState} from "react";
+import React, {FC, useEffect, useState} from "react";
 import {Pressable, View} from "react-native";
 
 import {AccordionProps} from "./Common";
 import {Heading} from "./Heading";
 import {Modal} from "./Modal";
+import {Text} from "./Text";
 import {useTheme} from "./Theme";
 
 export const Accordion: FC<AccordionProps> = ({
   children,
   isCollapsed = false,
   title,
+  subtitle,
   includeInfoModal = false,
   infoModalChildren,
-  infoModalSubTitle,
+  infoModalSubtitle,
   infoModalText,
   infoModalTitle,
 }) => {
   const {theme} = useTheme();
-  const [collapsed, setCollapsed] = useState(isCollapsed);
+  const [collapsed, setCollapsed] = useState(false);
   const [infoModalVisibleState, setInfoModalVisibleState] = useState(false);
+
+  // The external collapse state should override the internal collapse state.
+  useEffect(() => {
+    setCollapsed(isCollapsed);
+  }, [isCollapsed]);
 
   return (
     <>
@@ -27,7 +34,7 @@ export const Accordion: FC<AccordionProps> = ({
         primaryButtonOnClick={() => setInfoModalVisibleState(false)}
         primaryButtonText="Close"
         size="md"
-        subTitle={infoModalSubTitle}
+        subtitle={infoModalSubtitle}
         text={infoModalText}
         title={infoModalTitle}
         visible={infoModalVisibleState}
@@ -46,22 +53,23 @@ export const Accordion: FC<AccordionProps> = ({
         }}
       >
         <View style={{flexDirection: "row", justifyContent: "space-between", alignItems: "center"}}>
-          <View style={{flexDirection: "row", alignItems: "center"}}>
-            <Heading>{title}</Heading>
-            {includeInfoModal && infoModalTitle && (
-              <Pressable
-                accessibilityRole="button"
-                hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
-                style={{marginLeft: 8}}
-                onPress={() => setInfoModalVisibleState(true)}
-              >
-                <Heading color="secondaryLight" size="sm">
-                  ⓘ
-                </Heading>
-                {/* TODO: Figure out why FontAwesome6 'light' is not working */}
-                {/* <FontAwesome6 color={theme.text.secondaryLight} light name="circle-info" size={16}  light="circle-info"/> */}
-              </Pressable>
-            )}
+          <View style={{flexDirection: "column", gap: 4}}>
+            <View style={{flexDirection: "row", alignItems: "center"}}>
+              <Heading>{title}</Heading>
+              {includeInfoModal && infoModalTitle && (
+                <Pressable
+                  accessibilityRole="button"
+                  hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
+                  style={{marginLeft: 8}}
+                  onPress={() => setInfoModalVisibleState(true)}
+                >
+                  <Heading color="secondaryLight" size="sm">
+                    ⓘ
+                  </Heading>
+                </Pressable>
+              )}
+            </View>
+            {subtitle && <Text>{subtitle}</Text>}
           </View>
           <View>
             <Pressable

--- a/packages/ui/src/Badge.tsx
+++ b/packages/ui/src/Badge.tsx
@@ -12,6 +12,10 @@ export const Badge = ({
   secondary = false,
   variant,
   maxValue = 100,
+  customBackgroundColor,
+  customTextColor,
+  customBorderColor,
+  customIconColor,
 }: BadgeProps): React.ReactElement => {
   const {theme} = useTheme();
   const isIconOnly = variant === "iconOnly";
@@ -25,6 +29,7 @@ export const Badge = ({
     info: "#8FC1D2",
     success: "#7FD898",
     neutral: "#AAAAAA",
+    custom: "#AAAAAA",
   };
 
   if (secondary) {
@@ -54,6 +59,11 @@ export const Badge = ({
   } else if (status === "neutral") {
     badgeBgColor = secondary ? "neutralLight" : "neutralDark";
   }
+
+  const backgroundColor = status === "custom" ? customBackgroundColor : theme.surface[badgeBgColor];
+  const borderColor = status === "custom" ? customBorderColor : secondaryBorderColors[status];
+  const textColor = status === "custom" ? customTextColor : theme.text[badgeColor];
+  const iconColor = status === "custom" ? customIconColor : badgeColor;
 
   let badgeBorderRadius = theme.radius.default;
   if (isIconOnly) {
@@ -89,27 +99,26 @@ export const Badge = ({
             justifyContent: "center",
             alignItems: "center",
             paddingVertical: variant === "iconOnly" ? 1 : theme.spacing.xs,
-            paddingHorizontal:
-              variant === "iconOnly" ? (theme.spacing.xs as any) : theme.spacing.sm,
+            paddingHorizontal: variant === "iconOnly" ? theme.spacing.xs : theme.spacing.sm,
             flexDirection: "row",
-            borderRadius: badgeBorderRadius as any,
-            backgroundColor: theme.surface[badgeBgColor],
+            borderRadius: badgeBorderRadius,
+            backgroundColor,
             height: variant === "iconOnly" ? 16 : "auto",
             width: variant === "iconOnly" ? 16 : "auto",
           },
           isIconOnly && {height: 16, width: 16},
-          secondary && {borderWidth: 1, borderColor: secondaryBorderColors[status]},
+          secondary && {borderWidth: 1, borderColor},
         ]}
       >
         {Boolean(variant !== "numberOnly" && iconName) && (
-          <View style={{marginRight: variant === "iconOnly" ? 0 : (theme.spacing.sm as any)}}>
-            <Icon color={badgeColor} iconName={iconName!} size="xs" />
+          <View style={{marginRight: variant === "iconOnly" ? 0 : theme.spacing.sm}}>
+            <Icon color={iconColor} iconName={iconName!} size="xs" />
           </View>
         )}
         {Boolean(variant !== "iconOnly") && (
           <Text
             style={{
-              color: theme.text[badgeColor],
+              color: textColor,
               fontSize: 10,
               fontWeight: "700",
               fontFamily: "text",

--- a/packages/ui/src/Badge.tsx
+++ b/packages/ui/src/Badge.tsx
@@ -16,6 +16,7 @@ export const Badge = ({
   customTextColor,
   customBorderColor,
   customIconColor,
+  customIconName,
 }: BadgeProps): React.ReactElement => {
   const {theme} = useTheme();
   const isIconOnly = variant === "iconOnly";
@@ -112,7 +113,7 @@ export const Badge = ({
       >
         {Boolean(variant !== "numberOnly" && iconName) && (
           <View style={{marginRight: variant === "iconOnly" ? 0 : theme.spacing.sm}}>
-            <Icon color={iconColor} iconName={iconName!} size="xs" />
+            <Icon color={iconColor} iconName={customIconName ?? iconName!} size="xs" />
           </View>
         )}
         {Boolean(variant !== "iconOnly") && (

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -15,18 +15,18 @@ import {isNative} from "./Utilities";
 const ConfirmationModal: FC<{
   visible: boolean;
   title: string;
-  subTitle?: string;
+  subtitle?: string;
   text: string;
   onConfirm: () => void;
   onCancel: () => void;
-}> = ({visible, title, subTitle, text, onConfirm, onCancel}) => {
+}> = ({visible, title, subtitle, text, onConfirm, onCancel}) => {
   return (
     <Modal
       primaryButtonOnClick={onConfirm}
       primaryButtonText="Confirm"
       secondaryButtonOnClick={onCancel}
       secondaryButtonText="Cancel"
-      subTitle={subTitle}
+      subtitle={subtitle}
       title={title}
       visible={visible}
       onDismiss={onCancel}
@@ -145,7 +145,7 @@ const ButtonComponent: FC<ButtonProps> = ({
       </View>
       {withConfirmation && (
         <ConfirmationModal
-          subTitle={modalSubTitle}
+          subtitle={modalSubTitle}
           text={confirmationText}
           title={modalTitle}
           visible={showConfirmation}

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -1309,6 +1309,10 @@ export interface BadgeProps {
    */
   customIconColor?: IconColor;
   /**
+   * When status is "custom", determines the badge's icon
+   */
+  customIconName?: IconName;
+  /**
    * When status is "custom", determines the badge's text color.
    */
   customTextColor?: string;

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -31,7 +31,7 @@ export interface AccordionProps {
   /**
    * The subtitle of the information modal.
    */
-  infoModalSubTitle?: ModalProps["subTitle"];
+  infoModalSubtitle?: ModalProps["subtitle"];
 
   /**
    * The text content of the information modal.
@@ -48,6 +48,11 @@ export interface AccordionProps {
    * @default true
    */
   isCollapsed?: boolean;
+
+  /*
+   * The subtitle showed below the title of the accordion.
+   */
+  subtitle?: string;
 
   /**
    * The title of the accordion.
@@ -1731,7 +1736,7 @@ export interface ModalProps {
   /**
    * The subtitle of the modal.
    */
-  subTitle?: string;
+  subtitle?: string;
   /**
    * The text content of the modal.
    */

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -1297,6 +1297,22 @@ export interface AvatarProps {
 
 export interface BadgeProps {
   /**
+   * When status is "custom", determines the badge's background color.
+   */
+  customBackgroundColor?: string;
+  /**
+   * When status is "custom", determines the badge's border color.
+   */
+  customBorderColor?: string;
+  /**
+   * When status is "custom", determines the badge's icon color
+   */
+  customIconColor?: IconColor;
+  /**
+   * When status is "custom", determines the badge's text color.
+   */
+  customTextColor?: string;
+  /**
    * The name of the icon to display in the badge.
    */
   iconName?: IconName;
@@ -1320,7 +1336,7 @@ export interface BadgeProps {
    * The status of the badge. Determines its color and appearance.
    * @default "info"
    */
-  status?: "info" | "error" | "warning" | "success" | "neutral";
+  status?: "info" | "error" | "warning" | "success" | "neutral" | "custom";
 
   /**
    * The text or number to display inside the badge.

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -15,7 +15,7 @@ import {isNative} from "./Utilities";
 type ConfirmationModalProps = {
   visible: boolean;
   title: string;
-  subTitle?: string;
+  subtitle?: string;
   text: string;
   onConfirm: () => void;
   onCancel: () => void;
@@ -24,7 +24,7 @@ type ConfirmationModalProps = {
 const ConfirmationModal: FC<ConfirmationModalProps> = ({
   visible,
   title,
-  subTitle,
+  subtitle,
   text,
   onConfirm,
   onCancel,
@@ -35,7 +35,7 @@ const ConfirmationModal: FC<ConfirmationModalProps> = ({
       primaryButtonText="Confirm"
       secondaryButtonOnClick={onCancel}
       secondaryButtonText="Cancel"
-      subTitle={subTitle}
+      subtitle={subtitle}
       title={title}
       visible={visible}
       onDismiss={onCancel}
@@ -173,7 +173,7 @@ const IconButtonComponent: FC<IconButtonProps> = ({
       )}
       {withConfirmation && (
         <ConfirmationModal
-          subTitle={undefined}
+          subtitle={undefined}
           text={confirmationText}
           title={confirmationHeading}
           visible={showConfirmation}

--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -32,7 +32,7 @@ const getModalSize = (size: "sm" | "md" | "lg"): DimensionValue => {
 const ModalContent: FC<{
   children?: ModalProps["children"];
   title?: ModalProps["title"];
-  subTitle?: ModalProps["subTitle"];
+  subtitle?: ModalProps["subtitle"];
   text?: ModalProps["text"];
   primaryButtonText?: ModalProps["primaryButtonText"];
   primaryButtonDisabled?: ModalProps["primaryButtonDisabled"];
@@ -46,7 +46,7 @@ const ModalContent: FC<{
 }> = ({
   children,
   title,
-  subTitle,
+  subtitle,
   text,
   primaryButtonText,
   primaryButtonDisabled,
@@ -113,14 +113,14 @@ const ModalContent: FC<{
           <Heading size="lg">{title}</Heading>
         </View>
       )}
-      {subTitle && (
+      {subtitle && (
         <View
           accessibilityHint="Modal Sub Heading Text"
-          accessibilityLabel={subTitle}
+          accessibilityLabel={subtitle}
           accessibilityRole="text"
-          style={{alignSelf: "flex-start", marginTop: subTitle ? 8 : 0}}
+          style={{alignSelf: "flex-start", marginTop: subtitle ? 8 : 0}}
         >
-          <Text size="lg">{subTitle}</Text>
+          <Text size="lg">{subtitle}</Text>
         </View>
       )}
       {text && (
@@ -172,7 +172,7 @@ export const Modal: FC<ModalProps> = ({
   primaryButtonText,
   secondaryButtonText,
   size = "sm",
-  subTitle,
+  subtitle,
   text,
   title,
   visible,
@@ -201,7 +201,7 @@ export const Modal: FC<ModalProps> = ({
 
   const modalContentProps = {
     title,
-    subTitle,
+    subtitle,
     text,
     primaryButtonText,
     primaryButtonDisabled,

--- a/packages/ui/src/SegmentedControl.tsx
+++ b/packages/ui/src/SegmentedControl.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Pressable, View} from "react-native";
 
 import {SegmentedControlProps} from "./Common";
-import {Text} from "./Text";
+import {Heading} from "./Heading";
 import {useTheme} from "./Theme";
 
 export const SegmentedControl = ({
@@ -23,6 +23,7 @@ export const SegmentedControl = ({
         alignItems: "center",
         gap: 4,
         height,
+        maxHeight: height,
         borderRadius: theme.primitives.radius3xl,
         borderColor: theme.primitives.neutral300,
         borderWidth: 3,
@@ -52,7 +53,7 @@ export const SegmentedControl = ({
           }}
           onPress={() => onChange(index)}
         >
-          <Text>{item}</Text>
+          <Heading size="sm">{item}</Heading>
         </Pressable>
       ))}
     </View>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -105,7 +105,9 @@ export const TapToEdit = ({
         </View>
         <View style={{gap: 16}}>
           <Field
+            grow={fieldProps?.type === "textarea" ? fieldProps.grow ?? true : undefined}
             helperText={helperText}
+            row={fieldProps?.type === "textarea" ? 5 : undefined}
             type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
             value={value}
             onChange={setValue ?? (() => {})}
@@ -236,7 +238,7 @@ export const TapToEdit = ({
                 </Text>
               )}
             </Box>
-            {editable && (
+            {editable && fieldProps?.type !== "textarea" && (
               <Box
                 accessibilityHint=""
                 accessibilityLabel="Edit"


### PR DESCRIPTION
### **User description**
Also make the badge demo look a bit better.
[Fix up accordion, s/subTitle/subtitle/](https://github.com/FlourishHealth/ferns-ui/pull/673/commits/48fc73d71924f4a59a60c2f63c222eadacebfd80)
[Fix segmented control height](https://github.com/FlourishHealth/ferns-ui/pull/673/commits/f2c781ab6d6d2901b14e5540ea28644e1e4ce48b)
[Fix tap to edit text area being small](https://github.com/FlourishHealth/ferns-ui/pull/673/commits/bbef5197de8e594514c5cc66326ae6ea5c90cb0e)
___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added support for custom colors in the `Badge` component by introducing a new `customColor` prop.
- Updated `BadgeProps` interface to include `customColor` and a new `custom` status.
- Enhanced badge demo stories to showcase the new custom color functionality.
- Improved the clarity of existing badge examples in the demo.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Badge.stories.tsx</strong><dd><code>Add custom color examples and update badge stories.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/demo/stories/Badge.stories.tsx

<li>Added new badge examples with custom colors.<br> <li> Updated existing badge examples for clarity.<br> <li> Changed function parameter type to <code>Partial<BadgeProps></code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/673/files#diff-14ac708a02bd45bb565cf8d8f8e879a5bfab4d1270660b3951f21717f32a4680">+61/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Badge.tsx</strong><dd><code>Add custom color support to Badge component.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Badge.tsx

<li>Introduced <code>customColor</code> prop for custom badge colors.<br> <li> Added logic to handle custom badge background color.<br> <li> Simplified padding and border radius logic.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/673/files#diff-7df4a7c83b27a544f119217086fa0450a34556056feceae8204da72453847a59">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Common.ts</strong><dd><code>Extend BadgeProps with custom color and status.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Common.ts

<li>Added <code>customColor</code> and <code>custom</code> status to <code>BadgeProps</code>.<br> <li> Updated <code>status</code> prop to include <code>custom</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/673/files#diff-538e93b553971318d69ff6fff2ac103f295c4922e24bbe61c30897baa463bba1">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

