### PR TITLE
Fix fullWidth button with tooltip

### DIFF
--- a/apps/demo/stories/Button.stories.tsx
+++ b/apps/demo/stories/Button.stories.tsx
@@ -93,7 +93,7 @@ export const ConfirmationButton = () => {
       <Box paddingX={3} paddingY={3}>
         <Button
           text="Default Confirmation Modal"
-           withConfirmation
+          withConfirmation
           onClick={() => console.info("clicked")}
         />
       </Box>
@@ -102,7 +102,7 @@ export const ConfirmationButton = () => {
           confirmationText="And some custom text body!"
           modalTitle="A Custom Title"
           text="With Custom Modal Props"
-           withConfirmation
+          withConfirmation
           onClick={() => console.info("clicked")}
         />
       </Box>
@@ -112,14 +112,25 @@ export const ConfirmationButton = () => {
 
 export const FullWidthButtons = (props: Partial<ButtonProps>) => {
   return (
-    <Box paddingY={1}>
-      <Button
-        text="Default/Primary Full Width"
-        onClick={() => console.info("clicked")}
-        {...props}
-        fullWidth
-      />
-    </Box>
+    <>
+      <Box paddingY={1}>
+        <Button
+          text="Default/Primary Full Width"
+          onClick={() => console.info("clicked")}
+          {...props}
+          fullWidth
+        />
+      </Box>
+      <Box paddingY={1}>
+        <Button
+          text="Full Width with tooltip"
+          tooltipText="This is a tooltip"
+          onClick={() => console.info("clicked")}
+          {...props}
+          fullWidth
+        />
+      </Box>
+    </>
   );
 };
 

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -13,7 +13,7 @@ import {Portal} from "react-native-portalize";
 
 import {TooltipPosition, TooltipProps} from "./Common";
 import {Text} from "./Text";
-import { useTheme } from "./Theme";
+import {useTheme} from "./Theme";
 
 const TOOLTIP_OFFSET = 6;
 // How many pixels to leave between the tooltip and the edge of the screen
@@ -310,73 +310,67 @@ export const Tooltip: FC<TooltipProps> = ({text, children, idealPosition, includ
 
   return (
     <View>
-      <View
-        style={{
-          alignSelf: "flex-start",
-        }}
-      >
-        {visible && (
-          <Portal>
+      {visible && (
+        <Portal>
+          <View
+            style={{
+              position: "absolute",
+              zIndex: 999,
+              ...getTooltipPosition({...(measurement as Measurement), idealPosition}),
+            }}
+            onLayout={handleOnLayout}
+          >
+            {includeArrow && isWeb && (
+              <View style={arrowContainerStyles as ViewStyle}>
+                <Arrow color={theme.surface.secondaryExtraDark} position={finalPosition} />
+              </View>
+            )}
             <View
               style={{
-                position: "absolute",
-                zIndex: 999,
-                ...getTooltipPosition({...(measurement as Measurement), idealPosition}),
+                backgroundColor: theme.surface.secondaryExtraDark,
+                borderRadius: theme.radius.default,
+                paddingVertical: 2,
+                paddingHorizontal: 8,
+                maxWidth: 320,
+                display: "flex",
+                flexShrink: 1,
+                opacity: measurement.measured ? 1 : 0,
               }}
-              onLayout={handleOnLayout}
             >
-              {includeArrow && isWeb && (
-                <View style={arrowContainerStyles as ViewStyle}>
-                  <Arrow color={theme.surface.secondaryExtraDark} position={finalPosition} />
-                </View>
-              )}
-              <View
+              <Pressable
+                accessibilityHint="Tooltip information"
+                accessibilityLabel={text}
+                accessibilityRole="button"
                 style={{
                   backgroundColor: theme.surface.secondaryExtraDark,
                   borderRadius: theme.radius.default,
-                  paddingVertical: 2,
-                  paddingHorizontal: 8,
-                  maxWidth: 320,
-                  display: "flex",
-                  flexShrink: 1,
-                  opacity: measurement.measured ? 1 : 0,
                 }}
+                testID="tooltip-container"
+                onPress={() => setVisible(false)}
               >
-                <Pressable
-                  accessibilityHint="Tooltip information"
-                  accessibilityLabel={text}
-                  accessibilityRole="button"
-                  style={{
-                    backgroundColor: theme.surface.secondaryExtraDark,
-                    borderRadius: theme.radius.default,
-                  }}
-                  testID="tooltip-container"
-                  onPress={() => setVisible(false)}
-                >
-                  <Text color="inverted" size="sm">
-                    {text}
-                  </Text>
-                </Pressable>
-              </View>
+                <Text color="inverted" size="sm">
+                  {text}
+                </Text>
+              </Pressable>
             </View>
-          </Portal>
-        )}
-        <View
-          ref={childrenWrapperRef}
-          hitSlop={{top: 10, bottom: 10, left: 15, right: 15}}
-          onPointerEnter={() => {
-            handleHoverIn();
-            children.props.onHoverIn?.();
-          }}
-          onPointerLeave={() => {
-            handleHoverOut();
-            children.props.onHoverOut?.();
-          }}
-          onTouchStart={handleTouchStart}
-          {...(!isWeb && mobilePressProps)}
-        >
-          {children}
-        </View>
+          </View>
+        </Portal>
+      )}
+      <View
+        ref={childrenWrapperRef}
+        hitSlop={{top: 10, bottom: 10, left: 15, right: 15}}
+        onPointerEnter={() => {
+          handleHoverIn();
+          children.props.onHoverIn?.();
+        }}
+        onPointerLeave={() => {
+          handleHoverOut();
+          children.props.onHoverOut?.();
+        }}
+        onTouchStart={handleTouchStart}
+        {...(!isWeb && mobilePressProps)}
+      >
+        {children}
       </View>
     </View>
   );


### PR DESCRIPTION
### **User description**
- Added fullWidth demo with tooltip
- Removed extra View from Tooltip render
- Removed alignSelf styling on Tooltip container


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a new full-width button with a tooltip in the demo.
- Removed extra `View` wrapper from Tooltip render.
- Removed `alignSelf` styling on Tooltip container.
- Added `Pressable` component for accessibility and interaction in Tooltip.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Button.stories.tsx</strong><dd><code>Add full-width button with tooltip in demo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/demo/stories/Button.stories.tsx

<li>Added a new full-width button with a tooltip in the demo.<br> <li> Adjusted formatting for existing buttons.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/674/files#diff-ed90dae0169c01359c7535d917b4d7dbf48f3401785e9dc325e7b512df0ba8b9">+21/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tooltip.tsx</strong><dd><code>Refactor Tooltip component for better structure and accessibility</code></dd></summary>
<hr>

packages/ui/src/Tooltip.tsx

<li>Removed extra <code>View</code> wrapper from Tooltip render.<br> <li> Removed <code>alignSelf</code> styling on Tooltip container.<br> <li> Added <code>Pressable</code> component for accessibility and interaction.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/674/files#diff-0524c51f0c05cf856c330f121f2e77a3d692c6b22c42572b9c63d465d8d06827">+52/-58</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

