### PR TITLE
updated tap to edit

### DIFF
--- a/apps/demo/stories/TapToEdit.stories.tsx
+++ b/apps/demo/stories/TapToEdit.stories.tsx
@@ -43,53 +43,39 @@ export const TapStory = (): ReactElement => {
   const [url, setURL] = useState("https://en.wikipedia.org/wiki/React_Native#Implementation");
   return (
     <Box direction="column" display="flex" height="100%" scroll width="100%">
-      <TapToEdit
-        setValue={setText}
-        title="Text"
-        type="text"
-        value={text}
-        onSave={(value): void => {
-          setText(value);
-        }}
-      />
-      <TapToEdit
-        setValue={setText}
-        title="Text"
-        type="textarea"
-        value={textArea}
-        onSave={(value): void => {
-          setTextArea(value);
-        }}
-      />
-      <TapToEdit
-        setValue={setText}
-        showHelperTextAsTooltip
-        title="Text Tooltip"
-        type="text"
-        value={text}
-        onSave={(value): void => {
-          setText(value);
-        }}
-      />
-      <TapToEdit
-        setValue={setTextArea}
-        showHelperTextAsTooltip
-        title="Text Area Tooltip"
-        type="textarea"
-        value={textArea}
-        onSave={(value): void => {
-          setTextArea(value);
-        }}
-      />
-      <TapToEdit
-        setValue={setBool}
-        title="Boolean"
-        type="boolean"
-        value={bool}
-        onSave={(value): void => {
-          setBool(value);
-        }}
-      />
+      <Box>
+        <TapToEdit
+          setValue={setText}
+          title="Text"
+          type="text"
+          value={text}
+          onSave={(value): void => {
+            setText(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          setValue={setText}
+          title="Text"
+          type="textarea"
+          value={textArea}
+          onSave={(value): void => {
+            setTextArea(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          setValue={setBool}
+          title="Boolean"
+          type="boolean"
+          value={bool}
+          onSave={(value): void => {
+            setBool(value);
+          }}
+        />
+      </Box>
       {/* <TapToEdit
         setValue={setCurrency}
         title="Currency"
@@ -108,66 +94,63 @@ export const TapStory = (): ReactElement => {
           setPercent(value);
         }}
       /> */}
-      <TapToEdit
-        options={[
-          {label: "Option1", value: "Option1"},
-          {label: "Option2", value: "Option2"},
-        ]}
-        setValue={setSelect}
-        title="Select"
-        type="select"
-        value={select}
-        onSave={(value: any): void => {
-          setSelect(value);
-        }}
-      />
-      <TapToEdit
-        options={[
-          {label: "Option1", value: "Option1"},
-          {label: "Option2", value: "Option2"},
-          {label: "Option2", value: "Option3"},
-          {
-            label: "Really long option for testing some wrap around and such",
-            value: "Really long option for testing some wrap around and such",
-          },
-        ]}
-        setValue={setMultiselect}
-        title="Multi Select"
-        type="multiselect"
-        value={multiselect}
-        onSave={(value): void => {
-          setMultiselect(value);
-        }}
-      />
-      <TapToEdit
-        setValue={setAddress}
-        title="Address"
-        type="address"
-        value={address}
-        onSave={(value): void => {
-          setAddress(value);
-        }}
-      />
-      <TapToEdit
-        setValue={setURL}
-        title="URL"
-        type="url"
-        value={url}
-        onSave={(value): void => {
-          setURL(value);
-        }}
-      />
-
-      <TapToEdit
-        setValue={setText}
-        title="Text With Confirmation"
-        type="text"
-        value={text}
-        withConfirmation
-        onSave={(value): void => {
-          setText(value);
-        }}
-      />
+      <Box>
+        <TapToEdit
+          options={[
+            {label: "Option1", value: "Option1"},
+            {label: "Option2", value: "Option2"},
+          ]}
+          setValue={setSelect}
+          title="Select"
+          type="select"
+          value={select}
+          onSave={(value: any): void => {
+            setSelect(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          options={[
+            {label: "Option1", value: "Option1"},
+            {label: "Option2", value: "Option2"},
+            {label: "Option2", value: "Option3"},
+            {
+              label: "Really long option for testing some wrap around and such",
+              value: "Really long option for testing some wrap around and such",
+            },
+          ]}
+          setValue={setMultiselect}
+          title="Multi Select"
+          type="multiselect"
+          value={multiselect}
+          onSave={(value): void => {
+            setMultiselect(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          setValue={setAddress}
+          title="Address"
+          type="address"
+          value={address}
+          onSave={(value): void => {
+            setAddress(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          setValue={setURL}
+          title="URL"
+          type="url"
+          value={url}
+          onSave={(value): void => {
+            setURL(value);
+          }}
+        />
+      </Box>
     </Box>
   );
 };

--- a/apps/demo/stories/TapToEdit.stories.tsx
+++ b/apps/demo/stories/TapToEdit.stories.tsx
@@ -56,8 +56,8 @@ export const TapStory = (): ReactElement => {
       </Box>
       <Box>
         <TapToEdit
-          setValue={setText}
-          title="Text"
+          setValue={setTextArea}
+          title="Text Area"
           type="textarea"
           value={textArea}
           onSave={(value): void => {

--- a/apps/demo/stories/TapToEdit.stories.tsx
+++ b/apps/demo/stories/TapToEdit.stories.tsx
@@ -2,9 +2,17 @@ import {Box, TapToEdit} from "ferns-ui";
 import React, {ReactElement, useState} from "react";
 
 export const TapDemo = (): ReactElement => {
-  const [value, setValue] = useState("Santa Claus");
+  const [value, setValue] = useState("Santa Claus !");
   return (
-    <TapToEdit setValue={setValue} title="Name" type="text" value={value} onSave={(): void => {}} />
+    <TapToEdit
+      helperText="This is a some helper text to help you understand what you are editing."
+      setValue={setValue}
+      title="Name"
+      type="text"
+      value={value}
+      withConfirmation
+      onSave={(): void => {}}
+    />
   );
 };
 
@@ -55,7 +63,7 @@ export const TapStory = (): ReactElement => {
       />
       <TapToEdit
         setValue={setText}
-        showDescriptionAsTooltip
+        showHelperTextAsTooltip
         title="Text Tooltip"
         type="text"
         value={text}
@@ -65,7 +73,7 @@ export const TapStory = (): ReactElement => {
       />
       <TapToEdit
         setValue={setTextArea}
-        showDescriptionAsTooltip
+        showHelperTextAsTooltip
         title="Text Area Tooltip"
         type="textarea"
         value={textArea}
@@ -83,8 +91,6 @@ export const TapStory = (): ReactElement => {
         }}
       />
       {/* <TapToEdit
-        openApiField="namePronunciation"
-        openApiModel="users"
         setValue={setCurrency}
         title="Currency"
         type="currency"
@@ -94,8 +100,6 @@ export const TapStory = (): ReactElement => {
         }}
       /> */}
       {/* <TapToEdit
-        openApiField="name"
-        // openApiModel="users"
         setValue={setPercent}
         title="Percent"
         type="percent"
@@ -118,16 +122,15 @@ export const TapStory = (): ReactElement => {
         }}
       />
       <TapToEdit
-        // options={[
-        //   {label: "Option1", value: "Option1"},
-        //   {label: "Option2", value: "Option2"},
-        //   {label: "Option2", value: "Option3"},
-        //   {
-        //     label: "Really long option for testing some wrap around and such",
-        //     value: "Really long option for testing some wrap around and such",
-        //   },
-        // ]}
-        options={["option1"]}
+        options={[
+          {label: "Option1", value: "Option1"},
+          {label: "Option2", value: "Option2"},
+          {label: "Option2", value: "Option3"},
+          {
+            label: "Really long option for testing some wrap around and such",
+            value: "Really long option for testing some wrap around and such",
+          },
+        ]}
         setValue={setMultiselect}
         title="Multi Select"
         type="multiselect"

--- a/apps/demo/story-config/TapToEdit.config.tsx
+++ b/apps/demo/story-config/TapToEdit.config.tsx
@@ -4,7 +4,7 @@ import {TapToEdit} from "ferns-ui";
 
 export const TapToEditConfiguration: DemoConfiguration = {
   name: "Tap to edit",
-  component: TapToEdit, // Replace with actual component reference
+  component: TapToEdit,
   related: ["Tap to edit pattern", "Address tap-to-edit pattern"],
   description:
     "This element allows the user to see information and interact with an icon to edit it. See the pattern here.",

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2150,12 +2150,6 @@ export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value
   helperText?: string;
 
   /**
-   * Surface helperText as a tooltip rather than below the value.
-   * @default false
-   */
-  showHelperTextAsTooltip?: boolean;
-
-  /**
    * Only display the helperText in the UI while editing. if false, the helperText is always shown below the value.
    * @default true
    */

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2103,28 +2103,67 @@ export type TapToEditProps =
 export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   title: string;
   value: any;
-  // Not required if not editable.
+
+  /**
+   * Not required if not editable.
+   */
   setValue?: (value: any) => void;
-  // Not required if not editable.
+
+  /**
+   * Not required if not editable.
+   */
   onSave?: (value: any) => void | Promise<void>;
-  // Defaults to true
+
+  /**
+   * If false, the field will not be editable and will be disabled
+   * @default true
+   */
   editable?: boolean;
-  // enable edit mode from outside the component
+
+  /**
+   * Enable edit mode from outside the component.
+   */
   isEditing?: boolean;
-  // For changing how the non-editing row renders
-  rowBoxProps?: Partial<BoxProps>;
   transform?: (value: any) => string;
-  fieldComponent?: (setValue: () => void) => ReactElement;
+  /**
+   * Show a confirmation modal before saving the value.
+   * @default false
+   */
   withConfirmation?: boolean;
+
+  /**
+   * The text content of the confirmation modal.
+   * @default "Are you sure you want save your changes?"
+   */
   confirmationText?: string;
-  confirmationHeading?: string;
-  description?: string;
+
+  /**
+   * The title of the confirmation modal.
+   * @default "Confirm"
+   */
+  confirmationTitle?: string;
+
+  /**
+   * Field helperText, a description of the field surfaced in the UI
+   * @default "Confirm"
+   */
+  helperText?: string;
+
+  /**
+   * Surface helperText as a tooltip rather than below the value.
+   * @default false
+   */
+  showHelperTextAsTooltip?: boolean;
+
+  /**
+   * Only display the helperText in the UI while editing. if false, the helperText is always shown below the value.
+   * @default true
+   */
+  onlyShowHelperTextWhileEditing?: boolean;
+
   // openApi to supported in future
   // openApiModel?: string;
   // openApiField?: string;
-  showDescriptionAsTooltip?: boolean;
-  // Default true. If false, description is shown below the value always.
-  onlyShowDescriptionWhileEditing?: boolean;
 }
 
 export interface APIError {

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -20,7 +20,7 @@ const TapToEditTitle = ({
 }): ReactElement => {
   return (
     <View style={{flex: 1, justifyContent: "center"}}>
-      <Text bold>{title}:</Text>
+      <Text bold>{title}</Text>
       {Boolean(helperText && !onlyShowHelperTextWhileEditing) && (
         <Text color="secondaryLight" size="sm">
           {helperText}
@@ -103,44 +103,46 @@ export const TapToEdit = ({
         <View style={{flex: 1, justifyContent: "center"}}>
           <Text bold>{title}</Text>
         </View>
-        <Field
-          helperText={helperText}
-          type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
-          value={value}
-          onChange={setValue ?? (() => {})}
-          {...(fieldProps as any)}
-        />
-        {editing && !isEditing && (
-          <View style={{flexDirection: "row", justifyContent: "flex-end"}}>
-            <Button
-              text="Cancel"
-              variant="muted"
-              onClick={(): void => {
-                if (setValue) {
-                  setValue(initialValue);
-                }
-                setEditing(false);
-              }}
-            />
-            <View style={{marginLeft: 8}}>
+        <View style={{gap: 16}}>
+          <Field
+            helperText={helperText}
+            type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
+            value={value}
+            onChange={setValue ?? (() => {})}
+            {...(fieldProps as any)}
+          />
+          {editing && !isEditing && (
+            <View style={{flexDirection: "row", justifyContent: "flex-end", gap: 16}}>
               <Button
-                confirmationText={confirmationText}
-                modalTitle={confirmationTitle}
-                text="Save"
-                withConfirmation={withConfirmation}
-                onClick={async (): Promise<void> => {
-                  if (!onSave) {
-                    console.error("No onSave provided for editable TapToEdit");
-                  } else {
-                    setInitialValue(value);
-                    await onSave(value);
+                text="Cancel"
+                variant="muted"
+                onClick={(): void => {
+                  if (setValue) {
+                    setValue(initialValue);
                   }
                   setEditing(false);
                 }}
               />
+              <View style={{marginLeft: 8}}>
+                <Button
+                  confirmationText={confirmationText}
+                  modalTitle={confirmationTitle}
+                  text="Save"
+                  withConfirmation={withConfirmation}
+                  onClick={async (): Promise<void> => {
+                    if (!onSave) {
+                      console.error("No onSave provided for editable TapToEdit");
+                    } else {
+                      setInitialValue(value);
+                      await onSave(value);
+                    }
+                    setEditing(false);
+                  }}
+                />
+              </View>
             </View>
-          </View>
-        )}
+          )}
+        </View>
       </View>
     );
   } else {
@@ -206,18 +208,22 @@ export const TapToEdit = ({
           alignItems: fieldProps?.type === "textarea" ? "flex-start" : "center",
           flexDirection: fieldProps?.type === "textarea" ? "column" : "row",
           justifyContent: "space-between",
-          paddingHorizontal: 12,
-          paddingVertical: 8,
           width: "100%",
         }}
       >
-        <View style={{flexDirection: "row", width: "100%"}}>
+        <View style={{flexDirection: "row", width: "100%", gap: 16}}>
           <TapToEditTitle
             helperText={helperText}
             onlyShowHelperTextWhileEditing={onlyShowHelperTextWhileEditing}
             title={title}
           />
-          <View style={{flexDirection: "row", flex: 1, justifyContent: "flex-end", marginLeft: 8}}>
+          <View
+            style={{
+              flexDirection: "row",
+              flex: 1,
+              justifyContent: "flex-end",
+            }}
+          >
             <Box
               accessibilityHint=""
               accessibilityLabel="Link"

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -3,7 +3,7 @@ import {Linking} from "react-native";
 
 import {Box} from "./Box";
 import {Button} from "./Button";
-import {AddressInterface, BoxProps, FieldProps, TapToEditProps} from "./Common";
+import {AddressInterface, FieldProps, TapToEditProps} from "./Common";
 import {Field} from "./Field";
 import {Icon} from "./Icon";
 // import {useOpenAPISpec} from "./OpenAPIContext";
@@ -12,28 +12,28 @@ import {Tooltip} from "./Tooltip";
 
 const TapToEditTitle = ({
   title,
-  description,
-  showDescriptionAsTooltip,
-  onlyShowDescriptionWhileEditing,
+  helperText,
+  showHelperTextAsTooltip,
+  onlyShowHelperTextWhileEditing,
 }: {
-  onlyShowDescriptionWhileEditing?: boolean;
-  showDescriptionAsTooltip?: boolean;
+  onlyShowHelperTextWhileEditing?: boolean;
+  showHelperTextAsTooltip?: boolean;
   title: string;
-  description?: string;
+  helperText?: string;
 }): ReactElement => {
   const Title = (
     <Box flex="grow" justifyContent="center">
       <Text bold>{title}:</Text>
-      {Boolean(description && !showDescriptionAsTooltip && !onlyShowDescriptionWhileEditing) && (
+      {Boolean(helperText && !showHelperTextAsTooltip && !onlyShowHelperTextWhileEditing) && (
         <Text color="secondaryLight" size="sm">
-          {description}
+          {helperText}
         </Text>
       )}
     </Box>
   );
-  if (showDescriptionAsTooltip) {
+  if (showHelperTextAsTooltip) {
     return (
-      <Tooltip idealPosition="top" text={description}>
+      <Tooltip idealPosition="top" text={helperText}>
         {Title}
       </Tooltip>
     );
@@ -87,20 +87,18 @@ export const TapToEdit = ({
   onSave,
   editable = true,
   isEditing = false,
-  rowBoxProps,
   transform,
-  fieldComponent,
   withConfirmation = false,
   confirmationText = "Are you sure you want to save your changes?",
-  confirmationHeading = "Confirm",
-  description: propsDescription,
-  showDescriptionAsTooltip = false,
-  onlyShowDescriptionWhileEditing = true,
+  confirmationTitle = "Confirm",
+  helperText: propsHelperText,
+  showHelperTextAsTooltip = false,
+  onlyShowHelperTextWhileEditing = true,
   ...fieldProps
 }: TapToEditProps): ReactElement => {
   const [editing, setEditing] = useState(false);
   const [initialValue, setInitialValue] = useState();
-  const description: string | undefined = propsDescription;
+  const helperText: string | undefined = propsHelperText;
   // setInitialValue is called after initial render to handle the case where the value is updated
   useEffect(() => {
     setInitialValue(value);
@@ -115,23 +113,19 @@ export const TapToEdit = ({
   if (editable && (editing || isEditing)) {
     return (
       <Box direction="column">
-        {fieldComponent ? (
-          fieldComponent(setValue as any)
-        ) : (
-          <Field
-            helperText={description}
-            label={title}
-            type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
-            value={value}
-            onChange={setValue ?? (() => {})}
-            {...(fieldProps as any)}
-          />
-        )}
+        <Field
+          helperText={helperText}
+          label={title}
+          type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
+          value={value}
+          onChange={setValue ?? (() => {})}
+          {...(fieldProps as any)}
+        />
         {editing && !isEditing && (
           <Box direction="row">
             <Button
               confirmationText={confirmationText}
-              modalTitle={confirmationHeading}
+              modalTitle={confirmationTitle}
               text="Save"
               withConfirmation={withConfirmation}
               onClick={async (): Promise<void> => {
@@ -169,6 +163,7 @@ export const TapToEdit = ({
       // If no transform, try and display the value reasonably.
       if (fieldProps?.type === "boolean") {
         displayValue = value ? "Yes" : "No";
+        // TODO: put transform back in after field types are updated
         // } else if (fieldProps?.type === "percent") {
         //   // Prevent floating point errors from showing up by using parseFloat and precision.
         //   // Pass through parseFloat again to trim off insignificant zeroes.
@@ -224,13 +219,12 @@ export const TapToEdit = ({
         paddingX={3}
         paddingY={2}
         width="100%"
-        {...(rowBoxProps as Exclude<BoxProps, "onClick">)}
       >
         <Box direction="row" width="100%">
           <TapToEditTitle
-            description={description}
-            onlyShowDescriptionWhileEditing={onlyShowDescriptionWhileEditing}
-            showDescriptionAsTooltip={showDescriptionAsTooltip}
+            helperText={helperText}
+            onlyShowHelperTextWhileEditing={onlyShowHelperTextWhileEditing}
+            showHelperTextAsTooltip={showHelperTextAsTooltip}
             title={title}
           />
           <Box direction="row" flex="grow" justifyContent="end" marginLeft={2}>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -124,7 +124,7 @@ export const TapToEdit = ({
           {...(fieldProps as any)}
         />
         {editing && !isEditing && (
-          <View style={{flexDirection: "row"}}>
+          <View style={{flexDirection: "row", justifyContent: "flex-end"}}>
             <Button
               text="Cancel"
               variant="muted"

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -8,38 +8,26 @@ import {Field} from "./Field";
 import {Icon} from "./Icon";
 // import {useOpenAPISpec} from "./OpenAPIContext";
 import {Text} from "./Text";
-import {Tooltip} from "./Tooltip";
 
 const TapToEditTitle = ({
   title,
   helperText,
-  showHelperTextAsTooltip,
   onlyShowHelperTextWhileEditing,
 }: {
   onlyShowHelperTextWhileEditing?: boolean;
-  showHelperTextAsTooltip?: boolean;
   title: string;
   helperText?: string;
 }): ReactElement => {
-  const Title = (
+  return (
     <View style={{flex: 1, justifyContent: "center"}}>
       <Text bold>{title}:</Text>
-      {Boolean(helperText && !showHelperTextAsTooltip && !onlyShowHelperTextWhileEditing) && (
+      {Boolean(helperText && !onlyShowHelperTextWhileEditing) && (
         <Text color="secondaryLight" size="sm">
           {helperText}
         </Text>
       )}
     </View>
   );
-  if (showHelperTextAsTooltip) {
-    return (
-      <Tooltip idealPosition="top" text={helperText}>
-        {Title}
-      </Tooltip>
-    );
-  } else {
-    return Title;
-  }
 };
 
 export function formatAddress(address: AddressInterface, asString = false): string {
@@ -92,7 +80,6 @@ export const TapToEdit = ({
   confirmationText = "Are you sure you want to save your changes?",
   confirmationTitle = "Confirm",
   helperText: propsHelperText,
-  showHelperTextAsTooltip = false,
   onlyShowHelperTextWhileEditing = true,
   ...fieldProps
 }: TapToEditProps): ReactElement => {
@@ -228,7 +215,6 @@ export const TapToEdit = ({
           <TapToEditTitle
             helperText={helperText}
             onlyShowHelperTextWhileEditing={onlyShowHelperTextWhileEditing}
-            showHelperTextAsTooltip={showHelperTextAsTooltip}
             title={title}
           />
           <View style={{flexDirection: "row", flex: 1, justifyContent: "flex-end", marginLeft: 8}}>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -112,10 +112,12 @@ export const TapToEdit = ({
 
   if (editable && (editing || isEditing)) {
     return (
-      <Box direction="column">
+      <Box direction="column" width="100%">
+        <Box flex="grow" justifyContent="center">
+          <Text bold>{title}</Text>
+        </Box>
         <Field
           helperText={helperText}
-          label={title}
           type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
           value={value}
           onChange={setValue ?? (() => {})}
@@ -124,27 +126,27 @@ export const TapToEdit = ({
         {editing && !isEditing && (
           <Box direction="row">
             <Button
-              confirmationText={confirmationText}
-              modalTitle={confirmationTitle}
-              text="Save"
-              withConfirmation={withConfirmation}
-              onClick={async (): Promise<void> => {
-                if (!onSave) {
-                  console.error("No onSave provided for editable TapToEdit");
-                } else {
-                  setInitialValue(value);
-                  await onSave(value);
+              text="Cancel"
+              variant="muted"
+              onClick={(): void => {
+                if (setValue) {
+                  setValue(initialValue);
                 }
                 setEditing(false);
               }}
             />
             <Box marginLeft={2}>
               <Button
-                text="Cancel"
-                variant="muted"
-                onClick={(): void => {
-                  if (setValue) {
-                    setValue(initialValue);
+                confirmationText={confirmationText}
+                modalTitle={confirmationTitle}
+                text="Save"
+                withConfirmation={withConfirmation}
+                onClick={async (): Promise<void> => {
+                  if (!onSave) {
+                    console.error("No onSave provided for editable TapToEdit");
+                  } else {
+                    setInitialValue(value);
+                    await onSave(value);
                   }
                   setEditing(false);
                 }}

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -1,5 +1,5 @@
 import React, {ReactElement, useEffect, useState} from "react";
-import {Linking} from "react-native";
+import {Linking, View} from "react-native";
 
 import {Box} from "./Box";
 import {Button} from "./Button";
@@ -22,14 +22,14 @@ const TapToEditTitle = ({
   helperText?: string;
 }): ReactElement => {
   const Title = (
-    <Box flex="grow" justifyContent="center">
+    <View style={{flex: 1, justifyContent: "center"}}>
       <Text bold>{title}:</Text>
       {Boolean(helperText && !showHelperTextAsTooltip && !onlyShowHelperTextWhileEditing) && (
         <Text color="secondaryLight" size="sm">
           {helperText}
         </Text>
       )}
-    </Box>
+    </View>
   );
   if (showHelperTextAsTooltip) {
     return (
@@ -112,10 +112,10 @@ export const TapToEdit = ({
 
   if (editable && (editing || isEditing)) {
     return (
-      <Box direction="column" width="100%">
-        <Box flex="grow" justifyContent="center">
+      <View style={{flexDirection: "column", width: "100%"}}>
+        <View style={{flex: 1, justifyContent: "center"}}>
           <Text bold>{title}</Text>
-        </Box>
+        </View>
         <Field
           helperText={helperText}
           type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
@@ -124,7 +124,7 @@ export const TapToEdit = ({
           {...(fieldProps as any)}
         />
         {editing && !isEditing && (
-          <Box direction="row">
+          <View style={{flexDirection: "row"}}>
             <Button
               text="Cancel"
               variant="muted"
@@ -135,7 +135,7 @@ export const TapToEdit = ({
                 setEditing(false);
               }}
             />
-            <Box marginLeft={2}>
+            <View style={{marginLeft: 8}}>
               <Button
                 confirmationText={confirmationText}
                 modalTitle={confirmationTitle}
@@ -151,10 +151,10 @@ export const TapToEdit = ({
                   setEditing(false);
                 }}
               />
-            </Box>
-          </Box>
+            </View>
+          </View>
         )}
-      </Box>
+      </View>
     );
   } else {
     let displayValue = value;
@@ -214,22 +214,24 @@ export const TapToEdit = ({
     // For textarea to display correctly, we place the title on its own line, then the text
     // on the next line. This is because the textarea will take up the full width of the row.
     return (
-      <Box
-        alignItems={fieldProps?.type === "textarea" ? "start" : "center"}
-        direction={fieldProps?.type === "textarea" ? "column" : "row"}
-        justifyContent="between"
-        paddingX={3}
-        paddingY={2}
-        width="100%"
+      <View
+        style={{
+          alignItems: fieldProps?.type === "textarea" ? "flex-start" : "center",
+          flexDirection: fieldProps?.type === "textarea" ? "column" : "row",
+          justifyContent: "space-between",
+          paddingHorizontal: 12,
+          paddingVertical: 8,
+          width: "100%",
+        }}
       >
-        <Box direction="row" width="100%">
+        <View style={{flexDirection: "row", width: "100%"}}>
           <TapToEditTitle
             helperText={helperText}
             onlyShowHelperTextWhileEditing={onlyShowHelperTextWhileEditing}
             showHelperTextAsTooltip={showHelperTextAsTooltip}
             title={title}
           />
-          <Box direction="row" flex="grow" justifyContent="end" marginLeft={2}>
+          <View style={{flexDirection: "row", flex: 1, justifyContent: "flex-end", marginLeft: 8}}>
             <Box
               accessibilityHint=""
               accessibilityLabel="Link"
@@ -253,15 +255,15 @@ export const TapToEdit = ({
                 <Icon iconName="pencil" size="md" />
               </Box>
             )}
-          </Box>
-        </Box>
+          </View>
+        </View>
         {fieldProps?.type === "textarea" && (
           <>
-            <Box marginTop={2} paddingY={2} width="100%">
+            <View style={{marginTop: 8, paddingVertical: 8, width: "100%"}}>
               <Text align="left" underline={isClickable}>
                 {displayValue}
               </Text>
-            </Box>
+            </View>
             {editable && (
               <Box
                 accessibilityHint=""
@@ -276,7 +278,7 @@ export const TapToEdit = ({
             )}
           </>
         )}
-      </Box>
+      </View>
     );
   }
 };


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Enhanced `TapToEdit` component by adding new props: `helperText`, `onlyShowHelperTextWhileEditing`, `withConfirmation`, `confirmationText`, and `confirmationTitle`.
- Refactored layout by replacing `Box` with `View` for better consistency.
- Updated stories and configuration to reflect new props and layout changes.
- Removed deprecated props: `showDescriptionAsTooltip` and `onlyShowDescriptionWhileEditing`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.stories.tsx</strong><dd><code>Update TapToEdit stories with new props and layout changes</code></dd></summary>
<hr>

apps/demo/stories/TapToEdit.stories.tsx

<li>Added <code>helperText</code> and <code>withConfirmation</code> props to <code>TapToEdit</code> component.<br> <li> Reorganized <code>TapToEdit</code> components within <code>Box</code> components for better <br>layout.<br> <li> Removed <code>showDescriptionAsTooltip</code> prop and related code.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/675/files#diff-da538abe745f26b9a25d7be19da6922d5129cc4ea18805eca86c82fae0ede35b">+100/-114</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Common.ts</strong><dd><code>Add new props and update documentation for TapToEdit component</code></dd></summary>
<hr>

packages/ui/src/Common.ts

<li>Added new props: <code>helperText</code>, <code>onlyShowHelperTextWhileEditing</code>, <br><code>withConfirmation</code>, <code>confirmationText</code>, and <code>confirmationTitle</code>.<br> <li> Removed <code>showDescriptionAsTooltip</code> and <code>onlyShowDescriptionWhileEditing</code> <br>props.<br> <li> Updated comments and documentation for new props.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/675/files#diff-538e93b553971318d69ff6fff2ac103f295c4922e24bbe61c30897baa463bba1">+45/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Refactor TapToEdit component layout and add new props</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/TapToEdit.tsx

<li>Replaced <code>Box</code> with <code>View</code> for layout consistency.<br> <li> Added support for <code>helperText</code> and <code>onlyShowHelperTextWhileEditing</code> props.<br> <li> Updated save and cancel button layout.<br> <li> Removed <code>showDescriptionAsTooltip</code> and related logic.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/675/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+68/-78</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.config.tsx</strong><dd><code>Update TapToEdit configuration with component reference</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/demo/story-config/TapToEdit.config.tsx

- Updated `TapToEdit` component reference and related patterns.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/675/files#diff-a7ff250a4b1de5a6fc8eca2b8182d19977dadf04098e8a168c39353b9cb781cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

