### PR TITLE
Fixes round 2

### DIFF
--- a/apps/demo/stories/DateTimeField.stories.tsx
+++ b/apps/demo/stories/DateTimeField.stories.tsx
@@ -1,4 +1,4 @@
-import {Box, DateTimeField} from "ferns-ui";
+import {Box, DateTimeField, Text} from "ferns-ui";
 import React, {ReactElement, useState} from "react";
 
 export const DateTimeFieldDemo = (): ReactElement => {
@@ -31,6 +31,7 @@ export const DateTimeFieldStory = (): ReactElement => {
           setValue(v);
         }}
       />
+      <Text>Value: {value}</Text>
     </Box>
   );
 };
@@ -48,6 +49,7 @@ export const DateFieldStory = (): ReactElement => {
           setValue(v);
         }}
       />
+      <Text>Value: {value}</Text>
     </Box>
   );
 };
@@ -65,6 +67,7 @@ export const TimeFieldStory = (): ReactElement => {
           setValue(v);
         }}
       />
+      <Text>Value: {value}</Text>
     </Box>
   );
 };

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2402,6 +2402,12 @@ export interface SelectFieldPropsBase {
   helperText?: string;
 
   /**
+   * The function to call when the selected value changes.
+   * If requireValue is false and value is undefined, onChange will return empty string.
+   */
+  onChange: (value: string) => void;
+
+  /**
    * The options available for selection in the select field.
    * Each option should have a label and a value.
    */
@@ -2429,11 +2435,6 @@ export interface SelectFieldPropsWithoutRequire extends SelectFieldPropsBase {
    * The current value of the select field.
    */
   value?: string;
-
-  /**
-   * The function to call when the selected value changes.
-   */
-  onChange: (value: string | undefined) => void;
 }
 
 export interface SelectFieldPropsWithRequire extends SelectFieldPropsBase {

--- a/packages/ui/src/DateTimeActionSheet.tsx
+++ b/packages/ui/src/DateTimeActionSheet.tsx
@@ -340,7 +340,7 @@ const DateCalendar = ({
 
   // Check if the date is T00:00:00.000Z (it should be), otherwise treat it as a date in the
   // current timezone.
-  const dt = DateTime.fromISO(date).setZone("UTC");
+  const dt = DateTime.fromISO(date);
   let dateString: string;
   if (dt.hour === 0 && dt.minute === 0 && dt.second === 0) {
     dateString = dt.toISO()!;

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -26,7 +26,7 @@ export const DateTimeField = ({
           return printDateAndTime(val, {timezone, showTimezone: true});
         case "date":
         default:
-          return printDate(val, {timezone, showTimezone: true});
+          return printDate(val, {ignoreTime: true});
       }
     },
     [timezone, type]
@@ -108,9 +108,9 @@ export const DateTimeField = ({
         const month = cleanedInput.slice(0, 2);
         const day = cleanedInput.slice(2, 4);
         const year = cleanedInput.slice(4, 8);
-        parsedDate = DateTime.fromFormat(`${month}${day}${year}`, "MMddyyyy", {
-          zone: timezone,
-        });
+        parsedDate = DateTime.fromFormat(`${month}${day}${year}`, "MMddyyyy", {zone: timezone})
+          .startOf("day")
+          .toUTC(0, {keepLocalTime: true});
       }
 
       if (parsedDate?.isValid) {

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -48,7 +48,12 @@ export const Field: FC<FieldProps> = ({type, ...rest}) => {
   } else if (type === "boolean") {
     return <BooleanField {...(rest as BooleanFieldProps)} />;
   } else if (type && ["date", "time", "datetime"].includes(type)) {
-    return <DateTimeField {...(rest as DateTimeFieldProps)} />;
+    return (
+      <DateTimeField
+        {...(rest as DateTimeFieldProps)}
+        type={type as "date" | "time" | "datetime"}
+      />
+    );
   } else if (type === "address") {
     return <AddressField {...(rest as AddressFieldProps)} />;
   } else if (type === "customSelect") {

--- a/packages/ui/src/Page.tsx
+++ b/packages/ui/src/Page.tsx
@@ -61,7 +61,7 @@ export class Page extends React.Component<PageProps, {}> {
         <Box
           alignSelf="center"
           avoidKeyboard
-          color={this.props.color || "neutralLight"}
+          color={this.props.color || "white"}
           direction={this.props.direction || "column"}
           display={this.props.display || "flex"}
           flex="grow"

--- a/packages/ui/src/Page.tsx
+++ b/packages/ui/src/Page.tsx
@@ -61,7 +61,7 @@ export class Page extends React.Component<PageProps, {}> {
         <Box
           alignSelf="center"
           avoidKeyboard
-          color={this.props.color || "white"}
+          color={this.props.color || "base"}
           direction={this.props.direction || "column"}
           display={this.props.display || "flex"}
           flex="grow"

--- a/packages/ui/src/SelectField.tsx
+++ b/packages/ui/src/SelectField.tsx
@@ -28,8 +28,8 @@ export const SelectField: FC<SelectFieldProps> = ({
         placeholder={!requireValue ? clearOption : {}}
         value={value ?? ""}
         onValueChange={(v) => {
-          if (v === "" && !requireValue) {
-            (onChange as (val: string | undefined) => void)(undefined);
+          if (v === undefined || v === "") {
+            onChange("");
           } else {
             onChange(v);
           }

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -238,7 +238,7 @@ export const TapToEdit = ({
                 </Text>
               )}
             </Box>
-            {editable && fieldProps?.type !== "textarea" && (
+            {editable && (
               <Box
                 accessibilityHint=""
                 accessibilityLabel="Edit"
@@ -252,25 +252,11 @@ export const TapToEdit = ({
           </View>
         </View>
         {fieldProps?.type === "textarea" && (
-          <>
-            <View style={{marginTop: 8, paddingVertical: 8, width: "100%"}}>
-              <Text align="left" underline={isClickable}>
-                {displayValue}
-              </Text>
-            </View>
-            {editable && (
-              <Box
-                accessibilityHint=""
-                accessibilityLabel="Edit"
-                alignSelf="end"
-                marginLeft={2}
-                width={16}
-                onClick={(): void => setEditing(true)}
-              >
-                <Icon color="primary" iconName="pencil" size="md" />
-              </Box>
-            )}
-          </>
+          <View style={{marginTop: 8, paddingVertical: 8, width: "100%"}}>
+            <Text align="left" underline={isClickable}>
+              {displayValue}
+            </Text>
+          </View>
         )}
       </View>
     );


### PR DESCRIPTION
### **User description**
Update page default background to white
Move tap to edit icon back up
Fix SelectField to return "" instead of undefined
Fix DateTimeField's handling of Dates, off by one

___

### **PR Type**
Enhancement


___

### **Description**
- Updated the default background color of the `Page` component to white.
- Adjusted the `TapToEdit` component by removing the conditional check for textarea type and moving the tap to edit icon back up.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Page.tsx</strong><dd><code>Update default background color to white</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Page.tsx

- Changed default background color to white.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/678/files#diff-7ca38792cb6e167996ec983615ec9076ec784f839d768f2b75bf77a6164f4cbf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Adjust tap to edit icon position and remove textarea check</code></dd></summary>
<hr>

packages/ui/src/TapToEdit.tsx

<li>Removed conditional check for textarea type.<br> <li> Moved tap to edit icon back up.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/678/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+6/-20</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

