### PR TITLE
Fix links in TapToEdit

### DIFF
--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -233,7 +233,7 @@ export const TapToEdit = ({
               onClick={isClickable ? openLink : undefined}
             >
               {Boolean(fieldProps?.type !== "textarea") && (
-                <Text align="right" underline={isClickable}>
+                <Text align="right" skipLinking underline={isClickable}>
                   {displayValue}
                 </Text>
               )}


### PR DESCRIPTION
### **User description**
If a link was set, only the base domain would be used because Text intercepted the link (which would be the base domain) and would open it instead of the openLink function opening it.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in the `TapToEdit` component where links were being intercepted by the `Text` component, causing only the base domain to be used.
- Added the `skipLinking` prop to the `Text` component to prevent it from automatically handling links, allowing the `openLink` function to manage link opening as intended.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Fix link handling in `TapToEdit` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/TapToEdit.tsx

<li>Added <code>skipLinking</code> prop to <code>Text</code> component to prevent automatic link <br>interception.<br> <li> Ensured <code>openLink</code> function handles link opening correctly.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/682/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

