### PR TITLE
autofocus tap to edit when editing

### DIFF
--- a/apps/demo/stories/TapToEdit.stories.tsx
+++ b/apps/demo/stories/TapToEdit.stories.tsx
@@ -41,6 +41,10 @@ export const TapStory = (): ReactElement => {
     zipcode: "12345",
   });
   const [url, setURL] = useState("https://en.wikipedia.org/wiki/React_Native#Implementation");
+  const [number, setNumber] = useState(12345);
+  const [email, setEmail] = useState("email@example.com");
+  const [customSelect, setCustomSelect] = useState("Option1");
+
   return (
     <Box direction="column" display="flex" height="100%" scroll width="100%">
       <Box>
@@ -148,6 +152,43 @@ export const TapStory = (): ReactElement => {
           value={url}
           onSave={(value): void => {
             setURL(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          setValue={setNumber}
+          title="Number"
+          type="number"
+          value={number}
+          onSave={(value): void => {
+            setNumber(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          setValue={setEmail}
+          title="Email"
+          type="email"
+          value={email}
+          onSave={(value): void => {
+            setEmail(value);
+          }}
+        />
+      </Box>
+      <Box>
+        <TapToEdit
+          options={[
+            {label: "Option1", value: "Option1"},
+            {label: "Option2", value: "Option2"},
+          ]}
+          setValue={setCustomSelect}
+          title="Custom Select"
+          type="customSelect"
+          value={customSelect}
+          onSave={(value): void => {
+            setCustomSelect(value);
           }}
         />
       </Box>

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -119,7 +119,7 @@ export const TapToEdit = ({
             grow={fieldProps?.type === "textarea" ? fieldProps.grow ?? true : undefined}
             helperText={helperText}
             inputRef={
-              ["text", "textarea", "url"].includes(fieldProps?.type)
+              ["text", "textarea", "url", "email", "number"].includes(fieldProps?.type)
                 ? (ref: any) => (inputRef.current = ref)
                 : undefined
             }

--- a/packages/ui/src/TapToEdit.tsx
+++ b/packages/ui/src/TapToEdit.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useEffect, useState} from "react";
+import React, {ReactElement, useEffect, useRef, useState} from "react";
 import {Linking, View} from "react-native";
 
 import {Box} from "./Box";
@@ -93,6 +93,17 @@ export const TapToEdit = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // TODO: Auto focus on input when editing for field types other than text for accessibility
+  const inputRef = useRef<any>(null);
+
+  // bring the bring the input into focus when editing from within the component,
+  // but not when editing from outside
+  useEffect(() => {
+    if (editable && editing && !isEditing) {
+      inputRef.current?.focus();
+    }
+  }, [editable, editing, isEditing]);
+
   if (editable && !setValue) {
     throw new Error("setValue is required if editable is true");
   }
@@ -107,6 +118,11 @@ export const TapToEdit = ({
           <Field
             grow={fieldProps?.type === "textarea" ? fieldProps.grow ?? true : undefined}
             helperText={helperText}
+            inputRef={
+              ["text", "textarea", "url"].includes(fieldProps?.type)
+                ? (ref: any) => (inputRef.current = ref)
+                : undefined
+            }
             row={fieldProps?.type === "textarea" ? 5 : undefined}
             type={(fieldProps?.type ?? "text") as NonNullable<FieldProps["type"]>}
             value={value}


### PR DESCRIPTION
### **User description**
This works for text, textarea, and url types. It does not work with select, boolean fields, address, etc. Made a to-do for that, this is an improvement for now.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Added `useRef` to manage input focus within the `TapToEdit` component.
- Implemented `useEffect` to auto-focus on input fields when they become editable.
- Updated the `Field` component to conditionally assign the `inputRef` for text, textarea, and url types.
- Added a TODO comment to address auto-focus for other field types in the future.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TapToEdit.tsx</strong><dd><code>Implement auto-focus on input fields when editing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/TapToEdit.tsx

<li>Added <code>useRef</code> to manage input focus.<br> <li> Implemented <code>useEffect</code> to auto-focus on input when editing.<br> <li> Updated <code>Field</code> component to conditionally assign <code>inputRef</code>.<br> <li> Added a TODO comment for future improvements on other field types.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/683/files#diff-5c106f38db848acb6a5d382743af81c919163754380b895781575765bc292ecd">+17/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

