### PR TITLE
Flip default for Avatar.hasBorder to false

### DIFF
--- a/apps/demo/stories/Avatar.stories.tsx
+++ b/apps/demo/stories/Avatar.stories.tsx
@@ -15,6 +15,7 @@ export const AvatarDemo = (props: Partial<AvatarProps>) => {
   return (
     <Box>
       <Avatar
+        hasBorder
         name="Tony Stark"
         src={src}
         status="online"
@@ -31,15 +32,15 @@ export const AvatarInitials = () => {
   return (
     <Box direction="column" display="flex">
       <Text>Tony Stark</Text>
-      <Avatar name="Tony Stark" status="online" />
+      <Avatar hasBorder name="Tony Stark" status="online" />
       <Text>Tony Stark Jr</Text>
-      <Avatar name="Tony Stark Jr" status="online" />
+      <Avatar hasBorder name="Tony Stark Jr" status="online" />
       <Text>Tony Ironman Stark</Text>
-      <Avatar name="Tony Ironman Stark" status="online" />
+      <Avatar hasBorder name="Tony Ironman Stark" status="online" />
       <Text>Tony</Text>
-      <Avatar name="Tony" status="online" />
+      <Avatar hasBorder name="Tony" status="online" />
       <Text> Tony Stark Colored</Text>
-      <Avatar name="Tony Stark" status="online" />
+      <Avatar hasBorder name="Tony Stark" status="online" />
     </Box>
   );
 };
@@ -121,6 +122,7 @@ export const AvatarStatusDemo = () => {
       <Box paddingY={1}>
         <Text>{text}</Text>
         <Avatar
+          hasBorder
           name="Tony Stark"
           size={size}
           src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
@@ -152,6 +154,7 @@ export const AvatarImage = (): ReactElement => {
       <Text>Height: {xlImage.height}</Text>
 
       <Avatar
+        hasBorder
         name="Tony Stark"
         size="xl"
         src={xlImage.uri}

--- a/packages/ui/src/Avatar.tsx
+++ b/packages/ui/src/Avatar.tsx
@@ -46,7 +46,7 @@ const sizeIconPadding = {
 
 export const Avatar: FC<AvatarProps> = ({
   name,
-  hasBorder = true,
+  hasBorder = false,
   size = "md",
   src,
   onChange,


### PR DESCRIPTION
### **User description**
We don't use the border as often, plus works more in line with our other props where you specifiy "hasBorder" instead of "hasBorder={false}". With border is supposed to signify a new message.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Changed the default value of the `hasBorder` prop in the `Avatar` component from `true` to `false`.
- Updated storybook files to explicitly set `hasBorder` where needed to maintain visual consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Avatar.stories.tsx</strong><dd><code>Update Avatar storybook to reflect new hasBorder default</code>&nbsp; </dd></summary>
<hr>

apps/demo/stories/Avatar.stories.tsx

<li>Added <code>hasBorder</code> prop to multiple <code>Avatar</code> component instances in <br>storybook files.<br> <li> Ensured consistency with the new default value of <code>hasBorder</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/685/files#diff-d9483c3b3b646878964780ef30e8d62762a92d543e174acb9e966600acb03e4b">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Avatar.tsx</strong><dd><code>Change default hasBorder prop value to false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Avatar.tsx

- Changed default value of `hasBorder` prop from `true` to `false`.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/685/files#diff-39324aa18ac651293f7053efc00df10ebb11474006fe171786659bd9d5233cd1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

