### PR TITLE
UI Fixes Round 3

### DIFF
--- a/packages/ui/src/Box.tsx
+++ b/packages/ui/src/Box.tsx
@@ -128,6 +128,9 @@ export const Box = React.forwardRef((props: BoxProps, ref) => {
     lgDirection: (value: any) =>
       mediaQueryLargerThan("lg") ? {flexDirection: value, display: "flex"} : {},
     display: (value: any) => {
+      if (value === "none") {
+        return {display: "none"};
+      }
       return value === "flex" ? {flex: undefined} : {flex: 0, flexDirection: "row"};
     },
     flex: (value: string) => {

--- a/packages/ui/src/SegmentedControl.tsx
+++ b/packages/ui/src/SegmentedControl.tsx
@@ -36,10 +36,7 @@ export const SegmentedControl = ({
           accessibilityRole="button"
           style={{
             display: "flex",
-            paddingTop: theme.spacing.sm,
-            paddingBottom: theme.spacing.sm,
-            paddingLeft: theme.spacing.md,
-            paddingRight: theme.spacing.md,
+            paddingHorizontal: size === "md" ? theme.spacing.sm : theme.spacing.md,
             justifyContent: "center",
             alignItems: "center",
             height: "100%",

--- a/packages/ui/src/Toast.tsx
+++ b/packages/ui/src/Toast.tsx
@@ -99,8 +99,8 @@ export const Toast = ({
     throw new Error("Secondary not supported yet");
   }
 
-  if (!persistent && !onDismiss) {
-    console.warn("Toast is not persistent but no onDismiss callback provided");
+  if (persistent && !onDismiss) {
+    console.warn("Toast is persistent but no onDismiss callback provided");
   }
 
   if (variant === "warning") {


### PR DESCRIPTION
### **User description**
[Allow hiding Box](https://github.com/FlourishHealth/ferns-ui/commit/e943ae5234f77ec61194e42c5f74417d04b7e5db)
[Fix warning about onDismiss for Toast](https://github.com/FlourishHealth/ferns-ui/commit/f6f19ba221a0bb9c67921c5484dd55f57c9b6a75)
[Fix small segmented control on mobile](https://github.com/FlourishHealth/ferns-ui/commit/1fc19fe4c86186ef90ad7a1a549ef6c25afbf217)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added handling for `display: none` in the `Box` component to allow hiding the box.
- Simplified padding logic in the `SegmentedControl` component for better mobile support.
- Fixed the warning message logic for the `onDismiss` callback in the `Toast` component to correctly reflect the `persistent` property.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Box.tsx</strong><dd><code>Add handling for `display: none` in Box component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Box.tsx

- Added logic to handle `display: none` in the `display` function.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/686/files#diff-c573fcf572c93f7ebfb7b3178345a9e42987fae60e28d59edf508519e820471c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SegmentedControl.tsx</strong><dd><code>Simplify padding logic in SegmentedControl component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/SegmentedControl.tsx

- Simplified padding logic for segmented control based on size.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/686/files#diff-79e3808bfb196a936004ddb32ae3af12e107a650703b510d340b15e87edfb542">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Toast.tsx</strong><dd><code>Fix warning logic for onDismiss in Toast component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Toast.tsx

<li>Fixed warning message logic for <code>onDismiss</code> callback in Toast component.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/686/files#diff-758dac505436c671757c95807bc3373de17286f290521575aae6c1446adee67a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

