### PR TITLE
fix bug with textfield and datetimeactionsheet values not in sync

### DIFF
--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -1,6 +1,6 @@
 import {getCalendars} from "expo-localization";
 import {DateTime} from "luxon";
-import React, {useCallback, useState} from "react";
+import React, {useCallback, useEffect, useState} from "react";
 
 import {DateTimeFieldProps} from "./Common";
 import {DateTimeActionSheet} from "./DateTimeActionSheet";
@@ -147,6 +147,14 @@ export const DateTimeField = ({
   } else if (type === "date") {
     placeholder = "MM/dd/yyyy";
   }
+
+  // if the value of the overall field changes via prop from the parent,
+  // update the formattedDate to keep the value of the TextField and DateTimeActionSheet in sync
+  useEffect(() => {
+    if (value && formatValue(value) !== formattedDate) {
+      setFormattedDate(formatValue(value));
+    }
+  }, [formatValue, formattedDate, value]);
 
   return (
     <>

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -7,6 +7,7 @@ import {DateTimeActionSheet} from "./DateTimeActionSheet";
 import {printDate, printDateAndTime, printTime} from "./DateUtilities";
 import {TextField} from "./TextField";
 
+// TODO: allow use of keyboard to type in date/time
 export const DateTimeField = ({
   type,
   value,
@@ -143,9 +144,9 @@ export const DateTimeField = ({
   if (type === "time") {
     placeholder = "hh:mm a";
   } else if (type === "datetime") {
-    placeholder = "MM/dd/yyyy hh:mm a";
+    placeholder = "mm/dd/yyyy hh:mm a";
   } else if (type === "date") {
-    placeholder = "MM/dd/yyyy";
+    placeholder = "mm/dd/yyyy";
   }
 
   // if the value of the overall field changes via prop from the parent,


### PR DESCRIPTION
### **User description**
closes #687


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed the bug where `TextField` and `DateTimeActionSheet` values were not in sync by adding a `useEffect` hook.
- Corrected the placeholder format to be consistent across different date/time types.
- Added a TODO comment to allow keyboard input for date/time in the future.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimeField.tsx</strong><dd><code>Fix synchronization and placeholder consistency in DateTimeField</code></dd></summary>
<hr>

packages/ui/src/DateTimeField.tsx

<li>Added <code>useEffect</code> to synchronize <code>TextField</code> and <code>DateTimeActionSheet</code> <br>values.<br> <li> Corrected placeholder format consistency.<br> <li> Added a TODO comment for future enhancement.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/689/files#diff-bea8f5eb9bb3d85082ea2444cd9e7ddf5333cd199bcb204f64da2e8056c11f9e">+12/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

