### PR TITLE
Stop showing "loading font"

### DIFF
--- a/packages/ui/src/Heading.tsx
+++ b/packages/ui/src/Heading.tsx
@@ -35,17 +35,11 @@ export const Heading = ({
   const {theme} = useTheme();
 
   // TODO: make fonts part of theme.
-  const [fontsLoaded] = useFonts({
+  useFonts({
     heading: TitilliumWeb_600SemiBold,
     "heading-bold": TitilliumWeb_700Bold,
     "heading-semibold": TitilliumWeb_600SemiBold,
   });
-
-  // TODO: How should we handle unloaded fonts.
-  if (!fontsLoaded) {
-    // eslint-disable-next-line react-native/no-raw-text
-    return <NativeText>Loading fonts...</NativeText>;
-  }
 
   const style: StyleProp<TextStyle> = {};
 

--- a/packages/ui/src/Text.tsx
+++ b/packages/ui/src/Text.tsx
@@ -45,8 +45,7 @@ export const Text = ({
 }: TextProps): React.ReactElement => {
   const {theme} = useTheme();
 
-  // TODO: make fonts part of theme.
-  const [fontsLoaded] = useFonts({
+  useFonts({
     "text-bold": Nunito_700Bold,
     "text-bold-italic": Nunito_700Bold_Italic,
     "text-medium": Nunito_500Medium,
@@ -55,12 +54,6 @@ export const Text = ({
     "text-regular": Nunito_400Regular,
     "text-regular-italic": Nunito_400Regular_Italic,
   });
-
-  // TODO: How should we handle unloaded fonts.
-  if (!fontsLoaded) {
-    // eslint-disable-next-line react-native/no-raw-text
-    return <NativeText />;
-  }
 
   const style: TextStyle = {};
 


### PR DESCRIPTION
### **User description**
We get an flash where the text is all loading fonts on slow connections. Ugly unstyled text is preferable.


___

### **PR Type**
Enhancement


___

### **Description**
- Removed the conditional checks for font loading in `Heading` and `Text` components.
- Eliminated the "Loading fonts..." message in the `Heading` component.
- Simplified the usage of the `useFonts` hook in both components.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Heading.tsx</strong><dd><code>Remove font loading check and message in Heading component</code></dd></summary>
<hr>

packages/ui/src/Heading.tsx

<li>Removed the conditional check for font loading.<br> <li> Eliminated the display of "Loading fonts..." message.<br> <li> Simplified the <code>useFonts</code> hook usage.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/692/files#diff-daf709cc20d67089ef1e46994592a5f6e920ca55ae628ebf891b882badda37c1">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Text.tsx</strong><dd><code>Remove font loading check in Text component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Text.tsx

<li>Removed the conditional check for font loading.<br> <li> Simplified the <code>useFonts</code> hook usage.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/692/files#diff-b1fb72bfffb1bdaf03b5f95b8338eb55c7c0bf7091ba2a5c2745e14407e99612">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

