### PR TITLE
Add max-height to modal to enable scrolling elements

### DIFF
--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -69,6 +69,8 @@ const ModalContent: FC<{
         margin: "auto",
         borderRadius: theme.radius.default,
         width: sizePx,
+        overflow: "hidden",
+        maxHeight: "75%",
         ...(isMobile
           ? {}
           : {
@@ -134,7 +136,7 @@ const ModalContent: FC<{
         </View>
       )}
       {children && (
-        <View accessibilityRole="text" style={{marginTop: text ? 0 : 12}}>
+        <View accessibilityRole="text" style={{flex: 1, marginTop: text ? 0 : 12}}>
           {children}
         </View>
       )}


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the modal component by adding a `maxHeight` of 75% to allow for scrolling within the modal when content exceeds this height.
- Added `overflow: "hidden"` to prevent content overflow issues.
- Improved the layout handling by setting `flex: 1` on the children view to ensure it expands properly within the modal.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Modal.tsx</strong><dd><code>Enhance modal with max-height and improved layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Modal.tsx

<li>Added <code>overflow: "hidden"</code> and <code>maxHeight: "75%"</code> to the modal style.<br> <li> Modified the <code>children</code> view to have <code>flex: 1</code> for better layout handling.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/737/files#diff-3ab16d64d26e5ea343f785756eac0fdd776a49367e2c34dbf6b99bc524a0789f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information