### PR TITLE
fix invalid date issue when clearing value from date/time pickers + add watch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ You must wrap your app in a FernsProvider to use the theme, Toasts, and other fe
     # Install dependencies
     yarn install
 
+    # Initial build (including type generation)
+    yarn build
+
     # Build the UI continuously
-    yarn build -w
+    yarn watch
 
     # In a separate window, run one of the following to run the demo app:
     yarn web

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "clean": "rm -rf node_modules && rm -rf packages/ui/node_modules && rm -rf packages/demo/node_modules && yarn",
     "test": "yarn --cwd packages/ui test",
     "postinstall": "patch-package",
-    "upgrades": "cd apps/demo && npx expo install --fix && cd ../../ && node syncUiFromUiDemo.js && yarn"
+    "upgrades": "cd apps/demo && npx expo install --fix && cd ../../ && node syncUiFromUiDemo.js && yarn",
+    "watch": "yarn --cwd packages/ui dev"
   },
   "workspaces": {
     "packages": [

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -31,7 +31,7 @@ export const DateTimeField = ({
   const formatValue = useCallback(
     (val: string) => {
       if (!val) {
-        return placeholder;
+        return "";
       }
       switch (type) {
         case "time":

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -30,6 +30,9 @@ export const DateTimeField = ({
 
   const formatValue = useCallback(
     (val: string) => {
+      if (!val) {
+        return placeholder;
+      }
       switch (type) {
         case "time":
           return printTime(val, {timezone, showTimezone: true});


### PR DESCRIPTION
### **User description**
When clearing the value of a date/time picker, we were displaying "Invalid date" in the field instead of going back to the placeholder. return empty string so field goes back to showing default placeholder

Also adding a watch script and updating readme to ensure commands work when run from root directory


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Fixed the issue where clearing a date/time picker displayed "Invalid date" by returning an empty string to show the placeholder.
- Updated the README to correct the command for continuous UI building, replacing `yarn build -w` with `yarn watch`.
- Added a `watch` script in `package.json` to facilitate continuous UI development.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimeField.tsx</strong><dd><code>Fix placeholder display for cleared date/time pickers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/DateTimeField.tsx

<li>Added a condition to return an empty string when the value is not set.<br> <li> Ensures the placeholder is shown instead of "Invalid date" when <br>clearing the date/time picker.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/742/files#diff-bea8f5eb9bb3d85082ea2444cd9e7ddf5333cd199bcb204f64da2e8056c11f9e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update build instructions in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated instructions for building the UI continuously.<br> <li> Replaced <code>yarn build -w</code> with <code>yarn watch</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/742/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add watch script for continuous UI build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Added a new script `watch` for continuous UI development.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/742/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information