### PR TITLE
Ignore eslint 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        ignore:
+          - dependency-name: "eslint"
+            versions: ["9.x"]
         exclude-patterns:
           - "@expo/*"
           - "@react-native-community/*"
@@ -80,6 +83,9 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        ignore:
+          - dependency-name: "eslint"
+            versions: ["9.x"]
         exclude-patterns:
           - "@expo/*"
           - "@react-native-community/*"


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the dependabot configuration to ignore updates for `eslint` version 9.x.
- Applied these changes to both `ferns-ui-non-native` and `demo-non-native` groups to prevent automatic updates to this major version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Ignore eslint version 9.x in dependabot configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<li>Added configuration to ignore updates for <code>eslint</code> version 9.x.<br> <li> Applied changes to <code>ferns-ui-non-native</code> and <code>demo-non-native</code> groups.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/743/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information