### PR TITLE
Fix District of Columbia capitalization

### DIFF
--- a/packages/ui/src/Constants.ts
+++ b/packages/ui/src/Constants.ts
@@ -3265,7 +3265,7 @@ export const USSTATESLIST = [
   {label: "CO", value: "Colorado"},
   {label: "CT", value: "Connecticut"},
   {label: "DE", value: "Delaware"},
-  {label: "DC", value: "District Of Columbia"},
+  {label: "DC", value: "District of Columbia"},
   {label: "FL", value: "Florida"},
   {label: "GA", value: "Georgia"},
   {label: "HI", value: "Hawaii"},


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Corrected the capitalization of "District of Columbia" in the `USSTATESLIST` constant to ensure consistency and accuracy in the display of state names.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Constants.ts</strong><dd><code>Fix capitalization of "District of Columbia" in constants</code></dd></summary>
<hr>

packages/ui/src/Constants.ts

<li>Corrected the capitalization of "District of Columbia" in the US <br>states list.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/763/files#diff-196d59785d2cdf2debb3d934a08cd65ce218f5b41c6effcd3ce5f53d360575d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information