### PR TITLE
Use timezone with ignoreTime flag

### DIFF
--- a/apps/demo/stories/Field.stories.tsx
+++ b/apps/demo/stories/Field.stories.tsx
@@ -215,13 +215,14 @@ export const DateAndTimeFieldStory = () => {
   const [timeValue, setTimeValue] = useState(
     DateTime.now().set({hour: 12, minute: 0, second: 0}).toISO()
   );
-  const [value, setValue] = useState<string>(DateTime.now().toISO());
+  const [value, setValue] = useState<string>(DateTime.now().endOf("day").toISO());
   const [timezone, setTimezone] = useState<string | undefined>("America/New_York");
   return (
     <StorybookContainer>
       <TimezonePicker showLabel timezone={timezone} onChange={(tz) => setTimezone(tz)} />
       <Field
         helperText="Here's some help text"
+        timezone={timezone}
         title="Date Time Field"
         type="datetime"
         value={value}
@@ -233,16 +234,17 @@ export const DateAndTimeFieldStory = () => {
         disabled
         title="Time in local timezone"
         type="text"
-        value={printDateAndTime(value, {showTimezone: true})}
+        value={printDateAndTime(value, {timezone, showTimezone: true})}
         onChange={() => {}}
       />
 
       <Field
+        timezone={timezone}
         helperText="Here's some help text"
         title="Date Field"
         type="date"
-        value={dateValue}
-        onChange={setDateValue}
+        value={value}
+        onChange={setValue}
       />
 
       <Field

--- a/apps/demo/stories/Field.stories.tsx
+++ b/apps/demo/stories/Field.stories.tsx
@@ -215,25 +215,26 @@ export const DateAndTimeFieldStory = () => {
   const [timeValue, setTimeValue] = useState(
     DateTime.now().set({hour: 12, minute: 0, second: 0}).toISO()
   );
-  const [value, setValue] = useState<string>(DateTime.now().toISO());
+  const [value, setValue] = useState<string>(DateTime.now().endOf("day").toISO());
   const [timezone, setTimezone] = useState<string | undefined>("America/New_York");
   return (
     <StorybookContainer>
       <TimezonePicker showLabel timezone={timezone} onChange={(tz) => setTimezone(tz)} />
       <Field
         helperText="Here's some help text"
+        timezone={timezone}
         title="Date Time Field"
         type="datetime"
         value={value}
         onChange={(v: string) => {
-          setValue(v);
+          setValue(DateTime.fromISO(v).endOf("day").toISO()!);
         }}
       />
       <Field
         disabled
         title="Time in local timezone"
         type="text"
-        value={printDateAndTime(value, {showTimezone: true})}
+        value={printDateAndTime(value, {timezone, showTimezone: true})}
         onChange={() => {}}
       />
 
@@ -241,8 +242,8 @@ export const DateAndTimeFieldStory = () => {
         helperText="Here's some help text"
         title="Date Field"
         type="date"
-        value={dateValue}
-        onChange={setDateValue}
+        value={value}
+        onChange={setValue}
       />
 
       <Field

--- a/apps/demo/stories/Field.stories.tsx
+++ b/apps/demo/stories/Field.stories.tsx
@@ -215,8 +215,7 @@ export const DateAndTimeFieldStory = () => {
   const [timeValue, setTimeValue] = useState(
     DateTime.now().set({hour: 12, minute: 0, second: 0}).toISO()
   );
-  const [value, setValue] = useState<string>(DateTime.now().endOf("day").toISO());
-  const [timezone, setTimezone] = useState<string | undefined>("America/New_York");
+  const [timezone, setTimezone] = useState<string | undefined>(DateTime.now().zone.name);
   return (
     <StorybookContainer>
       <TimezonePicker showLabel timezone={timezone} onChange={(tz) => setTimezone(tz)} />
@@ -225,16 +224,14 @@ export const DateAndTimeFieldStory = () => {
         timezone={timezone}
         title="Date Time Field"
         type="datetime"
-        value={value}
-        onChange={(v: string) => {
-          setValue(v);
-        }}
+        value={dateValue}
+        onChange={setDateValue}
       />
-      <Field
+      {/* <Field
         disabled
         title="Time in local timezone"
         type="text"
-        value={printDateAndTime(value, {timezone, showTimezone: true})}
+        value={printDateAndTime(dateValue, {timezone, showTimezone: true})}
         onChange={() => {}}
       />
 
@@ -243,8 +240,8 @@ export const DateAndTimeFieldStory = () => {
         helperText="Here's some help text"
         title="Date Field"
         type="date"
-        value={value}
-        onChange={setValue}
+        value={dateValue}
+        onChange={setDateValue}
       />
 
       <Field
@@ -253,7 +250,7 @@ export const DateAndTimeFieldStory = () => {
         type="time"
         value={timeValue}
         onChange={setTimeValue}
-      />
+      /> */}
     </StorybookContainer>
   );
 };

--- a/apps/demo/stories/Field.stories.tsx
+++ b/apps/demo/stories/Field.stories.tsx
@@ -215,26 +215,25 @@ export const DateAndTimeFieldStory = () => {
   const [timeValue, setTimeValue] = useState(
     DateTime.now().set({hour: 12, minute: 0, second: 0}).toISO()
   );
-  const [value, setValue] = useState<string>(DateTime.now().endOf("day").toISO());
+  const [value, setValue] = useState<string>(DateTime.now().toISO());
   const [timezone, setTimezone] = useState<string | undefined>("America/New_York");
   return (
     <StorybookContainer>
       <TimezonePicker showLabel timezone={timezone} onChange={(tz) => setTimezone(tz)} />
       <Field
         helperText="Here's some help text"
-        timezone={timezone}
         title="Date Time Field"
         type="datetime"
         value={value}
         onChange={(v: string) => {
-          setValue(DateTime.fromISO(v).endOf("day").toISO()!);
+          setValue(v);
         }}
       />
       <Field
         disabled
         title="Time in local timezone"
         type="text"
-        value={printDateAndTime(value, {timezone, showTimezone: true})}
+        value={printDateAndTime(value, {showTimezone: true})}
         onChange={() => {}}
       />
 
@@ -242,8 +241,8 @@ export const DateAndTimeFieldStory = () => {
         helperText="Here's some help text"
         title="Date Field"
         type="date"
-        value={value}
-        onChange={setValue}
+        value={dateValue}
+        onChange={setDateValue}
       />
 
       <Field

--- a/apps/demo/stories/Field.stories.tsx
+++ b/apps/demo/stories/Field.stories.tsx
@@ -218,6 +218,7 @@ export const DateAndTimeFieldStory = () => {
   const [timezone, setTimezone] = useState<string | undefined>(DateTime.now().zone.name);
   return (
     <StorybookContainer>
+      <Heading>NOTE: The timezone picker below is to mimic the user's current timezone to test how dates/times are displayed</Heading>
       <TimezonePicker showLabel timezone={timezone} onChange={(tz) => setTimezone(tz)} />
       <Field
         helperText="Here's some help text"
@@ -227,7 +228,7 @@ export const DateAndTimeFieldStory = () => {
         value={dateValue}
         onChange={setDateValue}
       />
-      {/* <Field
+      <Field
         disabled
         title="Time in local timezone"
         type="text"
@@ -250,7 +251,7 @@ export const DateAndTimeFieldStory = () => {
         type="time"
         value={timeValue}
         onChange={setTimeValue}
-      /> */}
+      />
     </StorybookContainer>
   );
 };

--- a/packages/ui/src/DateTimeActionSheet.tsx
+++ b/packages/ui/src/DateTimeActionSheet.tsx
@@ -325,9 +325,11 @@ const DateCalendar = ({
   onDismiss,
   date,
   setDate,
+  timezone,
 }: {
   type: DateTimeActionSheetProps["type"];
   date: string;
+  timezone: string | undefined;
   setDate: (date: string) => void;
   onChange: DateTimeActionSheetProps["onChange"];
   onDismiss: DateTimeActionSheetProps["onDismiss"];
@@ -340,9 +342,7 @@ const DateCalendar = ({
 
   // Check if the date is T00:00:00.000Z (it should be), otherwise treat it as a date in the
   // current timezone.
-  console.log({date});
   const dt = DateTime.fromISO(date);
-  console.log({dt});
   let dateString: string;
   if (dt.hour === 0 && dt.minute === 0 && dt.second === 0) {
     dateString = dt.toISO()!;
@@ -351,7 +351,10 @@ const DateCalendar = ({
   }
 
   if (date) {
-    markedDates[DateTime.fromISO(dateString).toFormat("yyyy-MM-dd")] = {
+    const displayDate = timezone
+      ? DateTime.fromISO(dateString).setZone(timezone).toFormat("yyyy-MM-dd")
+      : DateTime.fromISO(dateString).toFormat("yyyy-MM-dd");
+    markedDates[displayDate] = {
       selected: true,
       selectedColor: theme.text.primary,
       customStyles: {
@@ -409,7 +412,6 @@ export const DateTimeActionSheet = ({
   onDismiss,
   timezone: tz,
 }: DateTimeActionSheetProps) => {
-  console.log({actionSheetValue: value, tz});
   const calendar = getCalendars()[0];
   const originalTimezone = (tz || calendar?.timeZone) ?? undefined;
   const [timezone, setTimezone] = useState<string | undefined>(originalTimezone);
@@ -506,11 +508,12 @@ export const DateTimeActionSheet = ({
     () => ({
       date,
       type,
+      timezone,
       setDate,
       onChange,
       onDismiss,
     }),
-    [date, type, setDate, onChange, onDismiss]
+    [date, type, setDate, onChange, onDismiss, timezone]
   );
 
   const timeProps = useMemo(
@@ -527,8 +530,6 @@ export const DateTimeActionSheet = ({
     }),
     [type, timezone, setTimezone, hour, setHour, minute, setMinute, amPm, setAmPm]
   );
-
-  console.log({dateProps});
 
   return (
     <Modal

--- a/packages/ui/src/DateTimeActionSheet.tsx
+++ b/packages/ui/src/DateTimeActionSheet.tsx
@@ -340,7 +340,9 @@ const DateCalendar = ({
 
   // Check if the date is T00:00:00.000Z (it should be), otherwise treat it as a date in the
   // current timezone.
+  console.log({date});
   const dt = DateTime.fromISO(date);
+  console.log({dt});
   let dateString: string;
   if (dt.hour === 0 && dt.minute === 0 && dt.second === 0) {
     dateString = dt.toISO()!;
@@ -407,6 +409,7 @@ export const DateTimeActionSheet = ({
   onDismiss,
   timezone: tz,
 }: DateTimeActionSheetProps) => {
+  console.log({actionSheetValue: value, tz});
   const calendar = getCalendars()[0];
   const originalTimezone = (tz || calendar?.timeZone) ?? undefined;
   const [timezone, setTimezone] = useState<string | undefined>(originalTimezone);
@@ -524,6 +527,8 @@ export const DateTimeActionSheet = ({
     }),
     [type, timezone, setTimezone, hour, setHour, minute, setMinute, amPm, setAmPm]
   );
+
+  console.log({dateProps});
 
   return (
     <Modal

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -50,7 +50,7 @@ export const DateTimeField = ({
           return printDateAndTime(val, {timezone, showTimezone: true});
         case "date":
         default:
-          return printDate(val, {ignoreTime: true});
+          return printDate(val, {timezone, ignoreTime: true});
       }
     },
     [timezone, type]
@@ -173,7 +173,9 @@ export const DateTimeField = ({
   // update the formattedDate to keep the value of the TextField and DateTimeActionSheet in sync
   useEffect(() => {
     if (value) {
+      console.log("value", value);
       const formatted = formatValue(value);
+      console.log("formatted", formatted);
       if (formattedDate !== formatted) {
         setFormattedDate(formatted);
       }

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -50,7 +50,7 @@ export const DateTimeField = ({
           return printDateAndTime(val, {timezone, showTimezone: true});
         case "date":
         default:
-          return printDate(val, {ignoreTime: true});
+          return printDate(val, {timezone, ignoreTime: true});
       }
     },
     [timezone, type]

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -50,7 +50,7 @@ export const DateTimeField = ({
           return printDateAndTime(val, {timezone, showTimezone: true});
         case "date":
         default:
-          return printDate(val, {timezone, ignoreTime: true});
+          return printDate(val, {ignoreTime: true});
       }
     },
     [timezone, type]
@@ -173,9 +173,7 @@ export const DateTimeField = ({
   // update the formattedDate to keep the value of the TextField and DateTimeActionSheet in sync
   useEffect(() => {
     if (value) {
-      console.log("value", value);
       const formatted = formatValue(value);
-      console.log("formatted", formatted);
       if (formattedDate !== formatted) {
         setFormattedDate(formatted);
       }

--- a/packages/ui/src/DateUtilities.tsx
+++ b/packages/ui/src/DateUtilities.tsx
@@ -154,17 +154,17 @@ export const printDate = (
     throw new Error(`printDate: ${error.message}`);
   }
 
-  if (!ignoreTime) {
-    return clonedDate.toLocaleString(DateTime.DATE_SHORT);
-  } else {
-    let justDate = DateTime.fromISO(date);
-
-    if(!timezone) {
-      justDate = justDate.setZone("UTC");
-    } 
-
-    return justDate.toFormat("M/d/yyyy");
+  if (ignoreTime) {
+    if (!date) {
+      throw new Error("printDate: Passed undefined");
+    }
+    // Use only the date component, ignore the time.
+    const justDate = DateTime.fromISO(date);
+    // We force it into UTC so we can get the correct date.
+    return justDate.setZone("UTC").toFormat("M/d/yyyy");
   }
+
+  return clonedDate.toLocaleString(DateTime.DATE_SHORT);
 };
 
 // For printing dates from date times, ignoring the time. These should end in T00:00:00.000Z.

--- a/packages/ui/src/DateUtilities.tsx
+++ b/packages/ui/src/DateUtilities.tsx
@@ -154,17 +154,17 @@ export const printDate = (
     throw new Error(`printDate: ${error.message}`);
   }
 
-  if (ignoreTime) {
-    if (!date) {
-      throw new Error("printDate: Passed undefined");
-    }
-    // Use only the date component, ignore the time.
-    const justDate = DateTime.fromISO(date);
-    // We force it into UTC so we can get the correct date.
-    return justDate.setZone("UTC").toFormat("M/d/yyyy");
-  }
+  if (!ignoreTime) {
+    return clonedDate.toLocaleString(DateTime.DATE_SHORT);
+  } else {
+    let justDate = DateTime.fromISO(date);
 
-  return clonedDate.toLocaleString(DateTime.DATE_SHORT);
+    if(!timezone) {
+      justDate = justDate.setZone("UTC");
+    } 
+
+    return justDate.toFormat("M/d/yyyy");
+  }
 };
 
 // For printing dates from date times, ignoring the time. These should end in T00:00:00.000Z.


### PR DESCRIPTION
### **User description**
We use the timezone if provided, if not we use UTC.


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the handling of timezones in the `Field` components by adding a `timezone` prop.
- Updated the `printDate` function to support `ignoreTime` with timezone, ensuring correct date formatting.
- Refactored logic in `DateUtilities.tsx` to use `startOf('day')` for normalizing the time component.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Field.stories.tsx</strong><dd><code>Enhance timezone handling in Field stories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/demo/stories/Field.stories.tsx

<li>Updated initial state of <code>value</code> to end of the day.<br> <li> Added <code>timezone</code> prop to <code>Field</code> components.<br> <li> Modified <code>printDateAndTime</code> function call to include <code>timezone</code>.<br> <li> Changed <code>onChange</code> handler for <code>Date Field</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/771/files#diff-03c487d65dedde02425b96460a0e9082a3020ea1307cdc988113da6eceede1fc">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DateTimeField.tsx</strong><dd><code>Include timezone in printDate function call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/DateTimeField.tsx

- Added `timezone` parameter to `printDate` function call.



</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/771/files#diff-bea8f5eb9bb3d85082ea2444cd9e7ddf5333cd199bcb204f64da2e8056c11f9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DateUtilities.tsx</strong><dd><code>Refactor printDate to support timezone and ignoreTime</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/DateUtilities.tsx

<li>Modified <code>printDate</code> to handle <code>ignoreTime</code> with timezone.<br> <li> Removed redundant error handling for <code>ignoreTime</code>.<br> <li> Adjusted logic to use <code>startOf('day')</code> for date normalization.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/771/files#diff-8a8e71df82a067f1d236e7099ae5a205dbbd4d672eb12974ff0b426ed20113db">+11/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information