### PR TITLE
Remove offset and localTime flag

### DIFF
--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -134,7 +134,7 @@ export const DateTimeField = ({
         const year = cleanedInput.slice(4, 8);
         parsedDate = DateTime.fromFormat(`${month}${day}${year}`, "MMddyyyy", {zone: timezone})
           .startOf("day")
-          .toUTC(0, {keepLocalTime: true});
+          .toUTC();
       }
 
       if (!parsedDate) {


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Removed the `keepLocalTime` flag from the `toUTC` method call to fix incorrect date parsing.
- Ensured that dates are correctly converted to UTC without maintaining local time, addressing potential bugs in date handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimeField.tsx</strong><dd><code>Fix date parsing by removing `keepLocalTime` flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/DateTimeField.tsx

<li>Removed the <code>keepLocalTime</code> option from the <code>toUTC</code> method call.<br> <li> Adjusted date parsing logic to ensure correct UTC conversion.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/786/files#diff-bea8f5eb9bb3d85082ea2444cd9e7ddf5333cd199bcb204f64da2e8056c11f9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information