### PR TITLE
Make href optional for Link

### DIFF
--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -684,7 +684,7 @@ export interface AddressFieldProps
 }
 
 export interface LinkProps {
-  href: string;
+  href?: string;
   text: string;
   onClick?: () => void;
   // TODO: support target on link
@@ -2060,7 +2060,7 @@ export interface TooltipProps {
 }
 
 export interface LinkProps extends TextProps {
-  href: string;
+  href?: string;
 }
 
 export type TapToEditProps =

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -2051,12 +2051,15 @@ export interface TooltipProps {
   text?: string;
 }
 
-export type LinkProps = TextProps &
-  (
+export type LinkProps = TextProps & {
+  text: string;
+} & (
     | {
         href: string;
+        onClick?: never;
       }
     | {
+        href?: never;
         onClick: () => void | Promise<void>;
       }
   );

--- a/packages/ui/src/Common.ts
+++ b/packages/ui/src/Common.ts
@@ -683,14 +683,6 @@ export interface AddressFieldProps
   onBlur?: (value: AddressInterface) => void;
 }
 
-export interface LinkProps {
-  href?: string;
-  text: string;
-  onClick?: () => void;
-  // TODO: support target on link
-  // target?: null | "blank";
-}
-
 export type Rounding =
   | "minimal" // alias "sm"
   | "default" // alias "md"
@@ -2059,9 +2051,15 @@ export interface TooltipProps {
   text?: string;
 }
 
-export interface LinkProps extends TextProps {
-  href?: string;
-}
+export type LinkProps = TextProps &
+  (
+    | {
+        href: string;
+      }
+    | {
+        onClick: () => void | Promise<void>;
+      }
+  );
 
 export type TapToEditProps =
   | (BaseTapToEditProps &

--- a/packages/ui/src/Link.tsx
+++ b/packages/ui/src/Link.tsx
@@ -12,7 +12,7 @@ export const Link = ({text, href, onClick}: LinkProps): React.ReactElement => {
     <Pressable
       aria-role="button"
       hitSlop={20}
-      onPress={() => (onClick ? onClick() : Linking.openURL(href))}
+      onPress={() => (onClick ? onClick() : href && Linking.openURL(href))}
     >
       <Text color="link" underline>
         {text}


### PR DESCRIPTION
### **User description**
We also have the option to use onClick, in which case we don't need href.


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Made the `href` property in the `LinkProps` interface optional to allow for flexibility in using either `href` or `onClick`.
- Updated the `Link` component to include error handling when neither `href` nor `onClick` is provided.
- Modified the `onPress` logic in the `Link` component to safely handle cases where `href` is not provided.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Common.ts</strong><dd><code>Make `href` property optional in `LinkProps` interface</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Common.ts

<li>Made the <code>href</code> property in <code>LinkProps</code> optional.<br> <li> Updated interface to reflect optional <code>href</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/794/files#diff-538e93b553971318d69ff6fff2ac103f295c4922e24bbe61c30897baa463bba1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Link.tsx</strong><dd><code>Update Link component to handle optional `href`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Link.tsx

<li>Added error handling for missing <code>href</code> and <code>onClick</code>.<br> <li> Modified <code>onPress</code> logic to handle optional <code>href</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/794/files#diff-fd851e8cf4e6de6304c2c49dbd342ede1146466bb23b7be7ab463d7ef334939f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information