### PR TITLE
Fix modal buttons getting pushed off

### DIFF
--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -129,7 +129,7 @@ const ModalContent: FC<{
         </View>
       )}
       {children && (
-        <View aria-role="text" style={{marginTop: text ? 0 : 12, width: "100%", height: "100%"}}>
+        <View aria-role="text" style={{marginTop: text ? 0 : 12, width: "100%", flex: 1}}>
           {children}
         </View>
       )}


### PR DESCRIPTION
### **User description**
The content should grow, not take up the entire modal content area, otherwise the buttons render off the modal. The content must grow to allow scrollable content inside the modal.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes modal content layout to prevent buttons from being pushed off

- Replaces fixed height with flexible growth for modal content

- Ensures scrollable content inside modal without affecting button visibility


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Modal.tsx</strong><dd><code>Make modal content flexibly grow to fix button overflow</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Modal.tsx

<li>Changed modal content container from fixed height to flexible growth <br>using <code>flex: 1</code><br> <li> Prevents modal buttons from being rendered off-screen when content <br>grows<br> <li> Ensures scrollable content within the modal


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/876/files#diff-3ab16d64d26e5ea343f785756eac0fdd776a49367e2c34dbf6b99bc524a0789f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>