### PR TITLE
Fix date picker showing previous day for date only values

### DIFF
--- a/packages/ui/src/DateTimeField.test.tsx
+++ b/packages/ui/src/DateTimeField.test.tsx
@@ -48,7 +48,7 @@ describe("DateTimeField", () => {
 
       // Verify that the time is set to 00:00:00
       const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
-      const date = DateTime.fromISO(lastCall);
+      const date = DateTime.fromISO(lastCall, {zone: "UTC"});
       expect(date.hour).toBe(0);
       expect(date.minute).toBe(0);
       expect(date.second).toBe(0);
@@ -73,7 +73,7 @@ describe("DateTimeField", () => {
 
       // Verify that the time is set to 00:00:00
       const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
-      const date = DateTime.fromISO(lastCall);
+      const date = DateTime.fromISO(lastCall, {zone: "UTC"});
       expect(date.hour).toBe(0);
       expect(date.minute).toBe(0);
       expect(date.second).toBe(0);
@@ -100,7 +100,7 @@ describe("DateTimeField", () => {
 
       // Verify that the time is set to 00:00:00
       const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
-      const date = DateTime.fromISO(lastCall);
+      const date = DateTime.fromISO(lastCall, {zone: "UTC"});
       expect(date.hour).toBe(0);
       expect(date.minute).toBe(0);
       expect(date.second).toBe(0);
@@ -300,7 +300,7 @@ describe("DateTimeField", () => {
 
       // Get the last call and check the time components
       const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
-      const date = DateTime.fromISO(lastCall);
+      const date = DateTime.fromISO(lastCall, {zone: "UTC"});
       // Only check that minutes and seconds are 0, as the hours may vary based on implementation
       expect(date.minute).toBe(0);
       expect(date.second).toBe(0);
@@ -357,7 +357,7 @@ describe("DateTimeField", () => {
 
       // Verify that the time is set to 00:00:00
       const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
-      const date = DateTime.fromISO(lastCall);
+      const date = DateTime.fromISO(lastCall, {zone: "UTC"});
       expect(date.hour).toBe(0);
       expect(date.minute).toBe(0);
       expect(date.second).toBe(0);

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -708,7 +708,7 @@ export const DateTimeField: React.FC<DateTimeFieldProps> = ({
           actionSheetRef={dateActionSheetRef}
           timezone={timezone}
           type={type}
-          value={type === "date" ? value?.split("T")[0] : value}
+          value={type === "date" ? value?.split("T")?.[0] : value}
           visible={showDate}
           onChange={onActionSheetChange}
           onDismiss={() => setShowDate(false)}

--- a/packages/ui/src/DateTimeField.tsx
+++ b/packages/ui/src/DateTimeField.tsx
@@ -351,7 +351,7 @@ export const DateTimeField: React.FC<DateTimeFieldProps> = ({
             day: parseInt(dayVal),
           },
           {
-            zone: override?.timezone ?? timezone,
+            zone: "UTC",
           }
         );
       } else {
@@ -708,7 +708,7 @@ export const DateTimeField: React.FC<DateTimeFieldProps> = ({
           actionSheetRef={dateActionSheetRef}
           timezone={timezone}
           type={type}
-          value={value}
+          value={type === "date" ? value?.split("T")[0] : value}
           visible={showDate}
           onChange={onActionSheetChange}
           onDismiss={() => setShowDate(false)}


### PR DESCRIPTION
### **User description**
Pass only the date value to the `DateTimeActionSheet` and keep date only values in UTC to prevent bug with calendar showing the previous day as the currently selected value.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix date picker showing previous day for date-only values

- Update date handling to use UTC timezone consistently

- Modify DateTimeActionSheet to receive only date portion for date-only fields

- Update test assertions to parse dates in UTC timezone


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Date Input"] --> B["UTC Timezone Processing"]
  B --> C["DateTimeActionSheet"]
  C --> D["Correct Date Display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimeField.tsx</strong><dd><code>Fix UTC timezone handling for date-only values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/DateTimeField.tsx

<ul><li>Change date object creation to use UTC timezone instead of <br>override/local timezone<br> <li> Pass only date portion (before 'T') to DateTimeActionSheet for <br>date-only fields</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/904/files#diff-bea8f5eb9bb3d85082ea2444cd9e7ddf5333cd199bcb204f64da2e8056c11f9e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateTimeField.test.tsx</strong><dd><code>Update tests to use UTC timezone parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/DateTimeField.test.tsx

<ul><li>Update all DateTime.fromISO calls to explicitly use UTC timezone<br> <li> Ensure test assertions parse dates consistently in UTC</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/904/files#diff-46a955c3afe6c7a88b32bc2348a4087709eea712d6df8ddc067fcc3a5b06ae0d">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

