### PR TITLE
wrap and alignItems is allowed on web, don't warn

### DIFF
--- a/packages/ui/src/Box.tsx
+++ b/packages/ui/src/Box.tsx
@@ -221,7 +221,7 @@ export const Box = React.forwardRef((props: BoxProps, ref) => {
       }
     }
 
-    if (props.wrap && props.alignItems) {
+    if (props.wrap && props.alignItems && Platform.OS !== "web") {
       console.warn("React Native doesn't support wrap and alignItems together.");
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove incorrect warning for `wrap` and `alignItems` on web platform


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Box component"] --> B["Platform check added"]
  B --> C["Warning only on non-web platforms"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Box.tsx</strong><dd><code>Add platform-specific warning condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/ui/src/Box.tsx

<ul><li>Added platform check to conditional warning<br> <li> Warning now only shows on non-web platforms</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/ferns-ui/pull/921/files#diff-c573fcf572c93f7ebfb7b3178345a9e42987fae60e28d59edf508519e820471c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

